### PR TITLE
Enhance trust model with more layers and memory loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This modular architecture is designed to evolve alongside AI needs, helping to r
 - Smart Deduplication: Basic and fuzzy matching to merge similar data
 - Flexible Categorization: Group context by roles and scopes
 - Context Fusion: Aggregate and weigh data for downstream AI
+- Customizable Trust Weights: Adjust context layer weights (role, environment, network, device, location, etc.) to fit your domain
 - Context Memory (with Cache Management): Efficient reuse and invalidation of context data and history data *(planned)*
 - Distributed Context Sync & Network Communication: Synchronize context state across nodes, support multi-agent collaboration, and enable context-aware messaging *(planned)*
 - AI Inference & Learning Hooks: Modular integration points for custom AI logic and model updates
@@ -70,10 +71,22 @@ This modular architecture is designed to evolve alongside AI needs, helping to r
    venv\Scripts\activate     # Windows
    ```
 3. Install dependencies (to be updated)
-    ```bash
-   pip install -r requirements.txt
-   Start by implementing your own ContextProvider or test the provided Redis provider.
-   ```
+```bash
+pip install -r requirements.txt
+Start by implementing your own ContextProvider or test the provided Redis provider.
+```
+
+### Loading Example Contexts
+
+```python
+from core.trust_module import TrustModule
+
+tm = TrustModule(weights={"role": 0.4, "location": 0.2, "device": 0.15, "action": 0.15, "time": 0.1})
+tm.load_examples([
+    {"role": 0.9, "location": 0.8, "time": 0.2, "device": 0.7, "action": 0.1},
+    {"role": 0.8, "location": 0.7, "time": 0.1, "device": 0.6, "action": 0.2},
+])
+```
    
 ## Contributing
 

--- a/core/trust_module.py
+++ b/core/trust_module.py
@@ -60,6 +60,10 @@ class TrustModule:
         """
         self.memory.append(context)
 
+    def load_examples(self, examples: List[Dict[str, float]]):
+        """Load multiple trusted contexts at once."""
+        self.memory.extend(examples)
+
     def get_max_similarity(self, context: Dict[str, float]) -> float:
         """
         Compare given context against all in memory and return max similarity score

--- a/docs/theory/trust.html
+++ b/docs/theory/trust.html
@@ -141,18 +141,20 @@
     </tr>
   </thead>
   <tbody>
-    <tr><td>Role</td><td>0.2</td><td>1</td></tr>
-    <tr><td>Environment</td><td>0.2</td><td>1</td></tr>
-    <tr><td>Network Data</td><td>0.15</td><td>0</td></tr>
-    <tr><td>Input Data</td><td>0.15</td><td>1</td></tr>
-    <tr><td>Timeframe</td><td>0.1</td><td>1</td></tr>
-    <tr><td>Mood</td><td>0.1</td><td>0</td></tr>
-    <tr><td>Label</td><td>0.1</td><td>1</td></tr>
+    <tr><td>Role</td><td>0.18</td><td>1</td></tr>
+    <tr><td>Environment</td><td>0.18</td><td>1</td></tr>
+    <tr><td>Network Data</td><td>0.12</td><td>0</td></tr>
+    <tr><td>Input Data</td><td>0.12</td><td>1</td></tr>
+    <tr><td>Timeframe</td><td>0.10</td><td>1</td></tr>
+    <tr><td>Mood</td><td>0.08</td><td>0</td></tr>
+    <tr><td>Label</td><td>0.10</td><td>1</td></tr>
+    <tr><td>Device</td><td>0.06</td><td>1</td></tr>
+    <tr><td>Location</td><td>0.06</td><td>0</td></tr>
   </tbody>
 </table>
 
 <div class="formula">
-  Trust = (0.2 + 0.2 + 0 + 0.15 + 0.1 + 0 + 0.1) / 1 = 0.75
+  Trust = (0.18 + 0.18 + 0 + 0.12 + 0.10 + 0 + 0.10 + 0.06 + 0) / 1 = 0.74
 </div>
 
 ---

--- a/interfaces/context_provider.py
+++ b/interfaces/context_provider.py
@@ -1,13 +1,16 @@
 class ContextProvider:
     def __init__(self):
+        # Weights sum to 1.0
         self.context_weights = {
-            "role": 0.2,
-            "environment": 0.2,
-            "network": 0.15,
-            "input": 0.15,
+            "role": 0.18,
+            "environment": 0.18,
+            "network": 0.12,
+            "input": 0.12,
             "timeframe": 0.1,
-            "mood": 0.1,
-            "label": 0.1  # Optional but powerful
+            "mood": 0.08,
+            "label": 0.1,  # Optional but powerful
+            "device": 0.06,
+            "location": 0.06,
         }
 
     def calculate_trust(self, context_data: dict) -> float:

--- a/tests/test_trust_module.py
+++ b/tests/test_trust_module.py
@@ -14,6 +14,14 @@ class TestTrustModule(unittest.TestCase):
         }
         self.tm = TrustModule(weights=self.weights, distance_method="cosine")
 
+    def test_load_examples(self):
+        examples = [
+            {"role": 0.9, "location": 0.8, "time": 0.0, "device": 0.7, "action": 0.1},
+            {"role": 0.8, "location": 0.7, "time": 0.2, "device": 0.6, "action": 0.2},
+        ]
+        self.tm.load_examples(examples)
+        self.assertEqual(len(self.tm.memory), 2)
+
     def test_base_trust_score(self):
         ctx = {
             "role": True,


### PR DESCRIPTION
## Summary
- extend context weights with device and location layers
- document updated weights and example trust score
- allow loading multiple trusted examples into `TrustModule`
- add README snippet for loading contexts
- test the new loader utility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch' / 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68483b905b1c832abaa0f8fab70b9343