### PR TITLE
Implement model management APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This modular architecture is designed to evolve alongside AI needs, helping to r
 - Context Memory (with Cache Management): Efficient reuse and invalidation of context data and history data *(planned)*
 - Distributed Context Sync & Network Communication: Synchronize context state across nodes, support multi-agent collaboration, and enable context-aware messaging. Basic support provided via `NetworkManager`, `SimpleNetworkMock`, and `DistributedContextManager`. See `docs/dev/network.html` for details.
 - AI Inference & Learning Hooks: Modular integration points for custom AI logic and model updates
+- Model Management: Replace, save, and load AI inference models at runtime
 
 ## Project Structure
 

--- a/core/ai_inference.py
+++ b/core/ai_inference.py
@@ -48,6 +48,10 @@ class AIInferenceEngine:
                 "confidence": 1.0,  # Placeholder, can implement confidence logic
             }
 
+    def predict(self, input_data: dict) -> dict:
+        """Public prediction API delegating to :meth:`infer`."""
+        return self.infer(input_data)
+
     def train(self, input_data: dict, target: float) -> float:
         """
         Train the model on input data with given target value.
@@ -75,3 +79,23 @@ class AIInferenceEngine:
         self.optimizer.step()
 
         return loss.item()
+
+    def replace_model(self, model: nn.Module, lr: float):
+        """Replace the underlying model and reinitialize optimizer and loss."""
+        self.model = model
+        self.model.to(self.device)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=lr)
+        self.loss_fn = nn.MSELoss()
+
+    def save_model(self, path: str):
+        """Persist the current model to ``path`` using :func:`torch.save`."""
+        if self.model is None:
+            raise RuntimeError("No model to save")
+        torch.save(self.model.state_dict(), path)
+
+    def load_model(self, path: str):
+        """Load model weights from ``path`` using :func:`torch.load`."""
+        if self.model is None:
+            raise RuntimeError("Model not initialized")
+        state = torch.load(path, map_location=self.device)
+        self.model.load_state_dict(state)

--- a/docs/dev/api_reference.html
+++ b/docs/dev/api_reference.html
@@ -67,6 +67,20 @@
 
   <h3>AIInference</h3>
   <p>Handles AI decision-making and prediction engines.</p>
+  <pre><code>class AIInferenceEngine:
+    def infer(self, input_data: dict) -> dict:
+        ...
+    def predict(self, input_data: dict) -> dict:
+        return self.infer(input_data)
+    def train(self, input_data: dict, target: float) -> float:
+        ...
+    def replace_model(self, model, lr: float):
+        ...
+    def save_model(self, path: str):
+        ...
+    def load_model(self, path: str):
+        ...
+  </code></pre>
 
   <h2>Example Usage</h2>
   <pre><code>from providers.redis_context_provider import RedisContextProvider


### PR DESCRIPTION
## Summary
- implement prediction helper in `AIInferenceEngine`
- add utilities to replace, save and load models
- document new methods in API reference
- mention model management feature in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684843d87f5c832ab16deacf3c41d524