### PR TITLE
Add feedback pipeline

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,7 @@
 from core.cache_manager import CacheManager
 from core.ai_inference import AIInferenceEngine
 from pipelines.context_pipeline import ContextPipeline
+from pipelines.feedback_pipeline import FeedbackPipeline
 from core.fuser import Fuser
 from core.context_manager import ContextManager
 from core.policy_evaluator import PolicyEvaluator
@@ -12,6 +13,7 @@ __all__ = [
     "CacheManager",
     "AIInferenceEngine",
     "ContextPipeline",
+    "FeedbackPipeline",
     "Fuser",
     "ContextManager",
     "PolicyEvaluator",

--- a/pipelines/__init__.py
+++ b/pipelines/__init__.py
@@ -1,0 +1,4 @@
+from .context_pipeline import ContextPipeline
+from .feedback_pipeline import FeedbackPipeline
+
+__all__ = ["ContextPipeline", "FeedbackPipeline"]

--- a/pipelines/feedback_pipeline.py
+++ b/pipelines/feedback_pipeline.py
@@ -1,0 +1,62 @@
+from typing import List, Optional, Tuple
+
+from core.categorizer import Categorizer
+from core.Deduplicars.fuzzy_deduplicator import FuzzyDeduplicator
+from interfaces.inference_engine import AIInferenceEngine
+from core.learning.learning_manager import LearningManager
+
+
+class FeedbackPipeline:
+    """Pipeline that categorizes context and feeds it directly into an inference
+    engine with optional learning feedback. No fusion step is performed."""
+
+    def __init__(
+        self,
+        context_provider,
+        inference_engine: AIInferenceEngine,
+        learning_manager: Optional[LearningManager] = None,
+        time_threshold_sec: int = 5,
+        fuzzy_threshold: float = 0.8,
+        merge_rule=None,
+    ):
+        self.categorizer = Categorizer(context_provider)
+        self.deduplicator = FuzzyDeduplicator(
+            time_threshold_sec=time_threshold_sec,
+            fuzzy_threshold=fuzzy_threshold,
+            merge_rule=merge_rule,
+        )
+        self.inference_engine = inference_engine
+        self.learning_manager = learning_manager
+
+    def run(
+        self,
+        data_batch: List[dict],
+        candidates: List[dict],
+        feedback: Optional[List[Tuple[str, float]]] = None,
+    ) -> List[dict]:
+        """Process a batch of context items and optionally apply feedback.
+
+        :param data_batch: Raw context items.
+        :param candidates: Categorization candidates.
+        :param feedback: Optional list of ``(log_line, corrected_label)`` tuples
+            used to update the ``LearningManager``.
+        :return: List of prediction dictionaries for each item.
+        """
+        deduped = self.deduplicator.deduplicate(data_batch)
+        results = []
+        for item in deduped:
+            category = self.categorizer.categorize(item, candidates)
+            item_copy = dict(item)
+            item_copy["category"] = category
+            prediction = self.inference_engine.predict(item_copy)
+            results.append({
+                "category": category,
+                "prediction": prediction,
+                "item": item_copy,
+            })
+
+        if feedback and self.learning_manager:
+            for log_line, label in feedback:
+                self.learning_manager.learn_from_feedback(log_line, label)
+
+        return results

--- a/tests/test_feedback_pipeline.py
+++ b/tests/test_feedback_pipeline.py
@@ -1,0 +1,39 @@
+import unittest
+
+from pipelines.feedback_pipeline import FeedbackPipeline
+from parser.log_parser import LogParser
+from core.learning.learning_manager import LearningManager
+from providers.mock_context_provider import MockContextProvider
+from interfaces.context_provider import ContextProvider
+
+
+class Provider(MockContextProvider, ContextProvider):
+    def __init__(self):
+        ContextProvider.__init__(self)
+
+
+class TestFeedbackPipeline(unittest.TestCase):
+    def test_feedback_pipeline_basic(self):
+        provider = Provider()
+        log_parser = LogParser()
+        manager = LearningManager(input_size=4, parser=log_parser)
+        pipeline = FeedbackPipeline(provider, manager, learning_manager=manager)
+
+        data_batch = provider.get_context()
+        candidates = [
+            {"category": "deal1", "context": {"deal": "1"}, "base_weight": 1.0},
+            {"category": "deal2", "context": {"deal": "2"}, "base_weight": 1.0},
+        ]
+
+        results = pipeline.run(data_batch, candidates)
+        self.assertIsInstance(results, list)
+        self.assertGreater(len(results), 0)
+        self.assertIn("prediction", results[0])
+
+        feedback = [(data_batch[0]["content"], 1.0)]
+        updated = pipeline.run([], [], feedback=feedback)
+        self.assertIsInstance(updated, list)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `FeedbackPipeline` for context flow without the fuser
- export new pipeline in `pipelines/__init__.py` and top level package
- add basic test for the new pipeline

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch' and 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6849cab73210832ab0f0143df9dc6b2d