### PR TITLE
Implement inference utilities and dummy tests

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,8 @@
 from core.cache_manager import CacheManager
-from core.ai_inference import AIInferenceEngine
+try:
+    from core.ai_inference import AIInferenceEngine
+except Exception:  # pragma: no cover - optional dependency may be missing
+    AIInferenceEngine = None
 from pipelines.context_pipeline import ContextPipeline
 from core.fuser import Fuser
 from core.context_manager import ContextManager

--- a/inference/complex_inference.py
+++ b/inference/complex_inference.py
@@ -46,3 +46,18 @@ class ComplexAIInferenceEngine(AIInferenceEngine):
 
     def get_model(self):
         return self.model
+
+    def replace_model(self, model: nn.Module, lr: float = 0.01):
+        """Replace the underlying model and optimizer."""
+        self.model = model
+        self.optimizer = torch.optim.Adam(self.model.parameters(), lr=lr)
+        self.loss_fn = nn.MSELoss()
+
+    def save_model(self, path: str):
+        """Persist the current model to ``path``."""
+        torch.save(self.model.state_dict(), path)
+
+    def load_model(self, path: str):
+        """Load model weights from ``path``."""
+        state = torch.load(path)
+        self.model.load_state_dict(state)

--- a/inference/dummy_engine.py
+++ b/inference/dummy_engine.py
@@ -17,3 +17,15 @@ class DummyAIInferenceEngine(AIInferenceEngine):
     def train(self, input_data: dict, target: float) -> float:
         # No training, just return 0 loss
         return 0.0
+
+    def replace_model(self, model, lr: float):
+        # Dummy engine has no model to replace
+        pass
+
+    def save_model(self, path: str):
+        # Nothing to save for the dummy engine
+        pass
+
+    def load_model(self, path: str):
+        # Nothing to load for the dummy engine
+        pass

--- a/interfaces/inference_engine.py
+++ b/interfaces/inference_engine.py
@@ -28,3 +28,15 @@ class AIInferenceEngine(ABC):
         By default, training is unsupported.
         """
         raise NotImplementedError("train method not implemented for this engine")
+
+    def replace_model(self, model, lr: float):
+        """Optional: Replace the underlying model and optimizer."""
+        raise NotImplementedError("replace_model not implemented for this engine")
+
+    def save_model(self, path: str):
+        """Optional: Persist the current model to ``path``."""
+        raise NotImplementedError("save_model not implemented for this engine")
+
+    def load_model(self, path: str):
+        """Optional: Load model weights from ``path``."""
+        raise NotImplementedError("load_model not implemented for this engine")

--- a/tests/ai_inference/test_dummy_ai_inference_engine.py
+++ b/tests/ai_inference/test_dummy_ai_inference_engine.py
@@ -1,0 +1,42 @@
+import importlib.util
+import os
+import pathlib
+import sys
+import pytest
+
+ROOT_DIR = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT_DIR))
+
+MODULE_PATH = ROOT_DIR / "inference" / "dummy_engine.py"
+spec = importlib.util.spec_from_file_location("dummy_engine", MODULE_PATH)
+dummy_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(dummy_module)
+DummyAIInferenceEngine = dummy_module.DummyAIInferenceEngine
+
+
+def test_infer_returns_expected_structure():
+    engine = DummyAIInferenceEngine()
+    data = {"foo": "bar"}
+    result = engine.infer(data)
+    assert result["result"] == "ok"
+    assert result["input_echo"] == data
+    assert result["confidence"] == 0.5
+
+
+def test_predict_delegates_to_infer():
+    engine = DummyAIInferenceEngine()
+    data = {"x": 1}
+    assert engine.predict(data) == engine.infer(data)
+
+
+def test_train_returns_zero():
+    engine = DummyAIInferenceEngine()
+    assert engine.train({}, 0.0) == 0.0
+
+
+def test_optional_methods_noop(tmp_path):
+    engine = DummyAIInferenceEngine()
+    engine.replace_model(None, 0.1)
+    path = tmp_path / "model.pt"
+    engine.save_model(str(path))
+    engine.load_model(str(path))


### PR DESCRIPTION
## Summary
- extend `AIInferenceEngine` base interface with optional model-management methods
- flesh out dummy and complex inference engines with save/load hooks
- guard top-level `__init__` against missing optional dependencies
- add a new test for `DummyAIInferenceEngine`

## Testing
- `pytest tests/ai_inference/test_dummy_ai_inference_engine.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6849cb82fc10832aa21b2ba07f783d44