### PR TITLE
Add CI workflow to run tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: Test Suite
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Run tests
+        run: |
+          pytest -vv


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run pytest for pull requests

## Testing
- `pip install numpy==2.2.6 sympy==1.14.0 redis==6.1.0 pytest==8.3.5`
- `pytest tests` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6849cf73cec8832a8be057b34d698958