### PR TITLE
Fix pyproject homepage field

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,4 +15,6 @@ dependencies = [
     "torch>=2.7.0",
     "sympy>=1.14.0",
 ]
-homepage = "https://github.com/Robo-Meister/ai-context-framework"
+
+[project.urls]
+Homepage = "https://github.com/Robo-Meister/ai-context-framework"


### PR DESCRIPTION
## Summary
- move homepage URL to `[project.urls]` in `pyproject.toml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6849d5261984832aaf3ff54452922e6a