### PR TITLE
Implement enhanced PolicyEvaluator

### DIFF
--- a/core/policy_evaluator.py
+++ b/core/policy_evaluator.py
@@ -1,26 +1,46 @@
 class PolicyEvaluator:
+    """Simple rule-based policy evaluator.
+
+    The evaluator maintains a collection of rule callables. Each rule is called
+    with ``(context, prediction)`` and should return either ``True``/``False`` or
+    a tuple ``(passed, prediction)``. In the latter case the returned prediction
+    is passed to subsequent rules allowing them to modify it.
     """
-    Evaluates a set of policy rules against context and prediction data.
-    Rejects or modifies inference output if rules are violated.
-    """
+
     def __init__(self, rules=None):
-        # rules is a list of callables: rule(context, prediction) -> bool
-        self.rules = rules or []
+        """Initialize the evaluator with an optional list of rules."""
+        self.rules = list(rules) if rules else []
 
     def add_rule(self, rule_callable):
-        """
-        Add a new rule callable.
-        """
+        """Register an additional rule."""
         self.rules.append(rule_callable)
 
-    def evaluate(self, context: dict, prediction: dict) -> (bool, dict):
-    # def evaluate(self, context_item: Dict[str, Any], prediction: dict) -> (bool, dict):
+    def evaluate(self, context: dict, prediction: dict | None = None) -> (bool, dict | None):
+        """Evaluate all configured rules.
+
+        Parameters
+        ----------
+        context:
+            Context data being checked.
+        prediction:
+            Optional prediction that can be modified by the rules.
+
+        Returns
+        -------
+        tuple[bool, dict | None]
+            ``(passed, prediction)`` where ``prediction`` may be updated by the
+            rules. ``passed`` is ``False`` if any rule fails.
         """
-        Evaluate all rules; return (passed, possibly modified prediction).
-        If any rule returns False, fail the policy check.
-        """
+
+        current_pred = prediction
         for rule in self.rules:
-            if not rule(context, prediction):
-                # Could log or raise alerts here
-                return False, None
-        return True, prediction
+            result = rule(context, current_pred)
+            if isinstance(result, tuple):
+                passed, new_pred = result
+                if not passed:
+                    return False, None
+                current_pred = new_pred
+            else:
+                if not result:
+                    return False, None
+        return True, current_pred

--- a/tests/test_policy_evaluator.py
+++ b/tests/test_policy_evaluator.py
@@ -1,0 +1,39 @@
+import unittest
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "policy_evaluator",
+    Path(__file__).resolve().parents[1] / "core" / "policy_evaluator.py",
+)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+PolicyEvaluator = module.PolicyEvaluator
+
+class TestPolicyEvaluator(unittest.TestCase):
+    def test_policy_pass_and_modify(self):
+        def rule_role(ctx, pred):
+            return ctx.get('role') == 'admin'
+
+        def rule_modify(ctx, pred):
+            new_pred = dict(pred or {})
+            new_pred['checked'] = True
+            return True, new_pred
+
+        evaluator = PolicyEvaluator([rule_role, rule_modify])
+        ok, result = evaluator.evaluate({'role': 'admin'}, {'value': 1})
+        self.assertTrue(ok)
+        self.assertEqual(result, {'value': 1, 'checked': True})
+
+    def test_policy_reject(self):
+        def rule_fail(ctx, pred):
+            return ctx.get('allowed', False)
+
+        evaluator = PolicyEvaluator([rule_fail])
+        ok, result = evaluator.evaluate({'allowed': False}, {})
+        self.assertFalse(ok)
+        self.assertIsNone(result)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- expand PolicyEvaluator to support rules that modify predictions
- add accompanying unit tests for PolicyEvaluator

## Testing
- `python -m unittest tests.test_policy_evaluator -v`
- `pytest tests/test_policy_evaluator.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_6849ee9d79fc832ab46542594d8bca52