### PR TITLE
Implement ContextBus and network hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This modular architecture is designed to evolve alongside AI needs, helping to r
 - Context Fusion: Aggregate and weigh data for downstream AI
 - Customizable Trust Weights: Adjust context layer weights (role, environment, network, device, location, etc.) to fit your domain
 - Context Memory (with Cache Management): Efficient reuse and invalidation of context data and history data
-- Distributed Context Sync & Network Communication: Synchronize context state across nodes, support multi-agent collaboration, and enable context-aware messaging. Basic support provided via `NetworkManager`, `SimpleNetworkMock`, and `DistributedContextManager`. See `docs/dev/network.html` for details.
+- Distributed Context Sync & Network Communication: Synchronize context state across nodes and trigger actions over the network. Includes `NetworkManager`, `SimpleNetworkMock`, `DistributedContextManager`, `ContextBus`, and network-aware hooks. See `docs/dev/network.html` for details.
 - AI Inference & Learning Hooks: Modular integration points for custom AI logic and model updates
 - Model Management: Replace, save, and load AI inference models at runtime
 

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,8 @@ from core import (
     CacheManager,
     ContextManager,
     DistributedContextManager,
+    ContextHookManager,
+    ContextHook,
     Fuser,
     PolicyEvaluator,
 )
@@ -13,7 +15,7 @@ except Exception:  # pragma: no cover - optional dependency may be missing
     AIInferenceEngine = None
 from pipelines import ContextPipeline, FeedbackPipeline
 from providers import MemoryContextProvider
-from network import NetworkManager, SimpleNetworkMock
+from network import NetworkManager, SimpleNetworkMock, ContextBus
 from interfaces import NetworkInterface
 
 __all__ = [
@@ -25,9 +27,12 @@ __all__ = [
     "Fuser",
     "ContextManager",
     "DistributedContextManager",
+    "ContextHookManager",
+    "ContextHook",
     "MemoryContextProvider",
     "PolicyEvaluator",
     "NetworkManager",
     "SimpleNetworkMock",
+    "ContextBus",
     "NetworkInterface",
 ]

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -4,6 +4,7 @@
 from .cache_manager import CacheManager
 from .context_manager import ContextManager
 from .distributed_context_manager import DistributedContextManager
+from .context_hooks import ContextHookManager, ContextHook
 from .fuser import Fuser
 from .policy_evaluator import PolicyEvaluator
 from .categorizer import Categorizer
@@ -14,6 +15,8 @@ __all__ = [
     "CacheManager",
     "ContextManager",
     "DistributedContextManager",
+    "ContextHookManager",
+    "ContextHook",
     "Fuser",
     "PolicyEvaluator",
     "Categorizer",

--- a/core/context_hooks.py
+++ b/core/context_hooks.py
@@ -1,0 +1,29 @@
+"""Hook system for reacting to context updates."""
+
+from dataclasses import dataclass
+from typing import Callable, List
+
+from interfaces.network_interface import NetworkInterface
+
+
+@dataclass
+class ContextHook:
+    """Represents a hook triggered by context changes."""
+
+    condition: Callable[[str, dict], bool]
+    action: Callable[[str, dict, NetworkInterface], None]
+
+
+class ContextHookManager:
+    """Manage context hooks and trigger them on updates."""
+
+    def __init__(self):
+        self._hooks: List[ContextHook] = []
+
+    def register_hook(self, condition: Callable[[str, dict], bool], action: Callable[[str, dict, NetworkInterface], None]):
+        self._hooks.append(ContextHook(condition, action))
+
+    def trigger(self, key: str, value: dict, network: NetworkInterface):
+        for hook in self._hooks:
+            if hook.condition(key, value):
+                hook.action(key, value, network)

--- a/docs/dev/network.html
+++ b/docs/dev/network.html
@@ -78,9 +78,18 @@ manager.update_context("task", {"status": "in_progress"})
 # ... other nodes receive the update ...
 </code></pre>
 
+<h2>ContextBus</h2>
 <p>
-Future work will introduce custom protocols and hooks at the context layer for
-more advanced swarm intelligence scenarios.
+  <code>ContextBus</code> mirrors context updates across multiple network backends
+  and can optionally filter updates before relaying them. It enables real-time
+  multi-node cooperation.
+</p>
+
+<h2>Network-Aware Hooks</h2>
+<p>
+  Hooks can be registered on <code>DistributedContextManager</code> and are
+  triggered whenever context updates occur. These hooks can broadcast new events
+  to the network or invoke external services.
 </p>
 
 </body>

--- a/network/__init__.py
+++ b/network/__init__.py
@@ -3,5 +3,6 @@
 
 from .network_manager import NetworkManager
 from .simple_network import SimpleNetworkMock
+from .context_bus import ContextBus
 
-__all__ = ["NetworkManager", "SimpleNetworkMock"]
+__all__ = ["NetworkManager", "SimpleNetworkMock", "ContextBus"]

--- a/network/context_bus.py
+++ b/network/context_bus.py
@@ -1,0 +1,24 @@
+"""Context bus for relaying context updates across multiple networks."""
+
+from typing import Callable, List, Optional
+from interfaces.network_interface import NetworkInterface
+
+
+class ContextBus:
+    """Simple in-memory context relay between multiple network backends."""
+
+    def __init__(self, networks: Optional[List[NetworkInterface]] = None, filter_fn: Optional[Callable[[str, dict], bool]] = None):
+        self.networks: List[NetworkInterface] = networks or []
+        self.filter_fn = filter_fn
+
+    def add_network(self, network: NetworkInterface):
+        """Register an additional network backend."""
+        self.networks.append(network)
+
+    def publish(self, key: str, value: dict):
+        """Broadcast a context update to all registered networks."""
+        if self.filter_fn and not self.filter_fn(key, value):
+            return
+        message = {"key": key, "value": value}
+        for net in self.networks:
+            net.send("all_nodes", message)

--- a/tests/network/test_context_bus.py
+++ b/tests/network/test_context_bus.py
@@ -1,0 +1,25 @@
+import unittest
+from unittest.mock import MagicMock
+
+from network.context_bus import ContextBus
+from interfaces.network_interface import NetworkInterface
+
+
+class TestContextBus(unittest.TestCase):
+    def test_publish_sends_to_all_networks(self):
+        n1 = MagicMock(spec=NetworkInterface)
+        n2 = MagicMock(spec=NetworkInterface)
+        bus = ContextBus([n1, n2])
+        bus.publish("k", {"v": 1})
+        n1.send.assert_called_once_with("all_nodes", {"key": "k", "value": {"v": 1}})
+        n2.send.assert_called_once_with("all_nodes", {"key": "k", "value": {"v": 1}})
+
+    def test_filter_prevents_publish(self):
+        n1 = MagicMock(spec=NetworkInterface)
+        bus = ContextBus([n1], filter_fn=lambda k, v: False)
+        bus.publish("k", {"v": 1})
+        n1.send.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/network/test_network_hooks.py
+++ b/tests/network/test_network_hooks.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest.mock import MagicMock
+
+from core.context_manager import ContextManager
+from core.distributed_context_manager import DistributedContextManager
+from interfaces.network_interface import NetworkInterface
+
+
+class TestNetworkHooks(unittest.TestCase):
+    def setUp(self):
+        self.cache = ContextManager()
+        self.network = MagicMock(spec=NetworkInterface)
+        self.manager = DistributedContextManager(self.cache, self.network)
+
+    def test_hook_triggered_on_update(self):
+        captured = []
+        self.manager.register_hook(lambda k, v: k == "task", lambda k, v, n: captured.append((k, v)))
+        self.manager.update_context("task", {"a": 1})
+        self.assertEqual(captured, [("task", {"a": 1})])
+
+    def test_hook_can_use_network(self):
+        self.manager.register_hook(lambda k, v: True, lambda k, v, n: n.broadcast({"event": k}))
+        self.manager.update_context("t", {"b": 2})
+        self.network.broadcast.assert_called_once_with({"event": "t"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `ContextBus` for mirroring context between networks
- add `ContextHookManager` and integrate hooks in `DistributedContextManager`
- expose new modules in package init files
- document networking additions
- add tests for bus and hooks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849f14e77e4832a90384103daa54e4c