### PR TITLE
Add roadmap link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ We welcome contributions of all kinds — feature ideas, bug fixes, documentatio
 
 Please fork the repo, create a feature branch, and open a pull request. Use issues for discussion and tracking.
 
+For an outline of ongoing development plans and upcoming features, see [docs/dev/TECHNICAL_ROADMAP.md](docs/dev/TECHNICAL_ROADMAP.md).
+
 ## License
 
 MIT License — see LICENSE file.


### PR DESCRIPTION
## Summary
- note where to find the technical roadmap

## Testing
- `pip install -r requirements.txt` *(fails: Operation cancelled by user)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684a045b9fb4832aae1659f25fb66c5b