### PR TITLE
Implement time-decay scoring and ANN index

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -10,6 +10,8 @@ from .policy_evaluator import PolicyEvaluator
 from .categorizer import Categorizer
 from .context_filer import ContextFilter
 from .trust_module import TrustModule
+from .time_decay_scorer import TimeDecayScorer
+from .ann_index import ANNIndex
 
 __all__ = [
     "CacheManager",
@@ -22,4 +24,6 @@ __all__ = [
     "Categorizer",
     "ContextFilter",
     "TrustModule",
+    "TimeDecayScorer",
+    "ANNIndex",
 ]

--- a/core/ann_index.py
+++ b/core/ann_index.py
@@ -1,0 +1,24 @@
+from typing import List
+from annoy import AnnoyIndex
+
+
+class ANNIndex:
+    """Simple wrapper around Annoy for approximate nearest neighbor search."""
+
+    def __init__(self, vector_dim: int, metric: str = "euclidean"):
+        self.vector_dim = vector_dim
+        self.index = AnnoyIndex(vector_dim, metric)
+        self.id_map: dict[int, str] = {}
+        self._next = 0
+
+    def add_item(self, item_id: str, vector: List[float]):
+        self.index.add_item(self._next, vector)
+        self.id_map[self._next] = item_id
+        self._next += 1
+
+    def build(self, n_trees: int = 10):
+        self.index.build(n_trees)
+
+    def query(self, vector: List[float], k: int = 5) -> List[str]:
+        ids = self.index.get_nns_by_vector(vector, k)
+        return [self.id_map[i] for i in ids]

--- a/core/time_decay_scorer.py
+++ b/core/time_decay_scorer.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+import math
+from interfaces.context_scorer import ContextScorer
+
+
+class TimeDecayScorer(ContextScorer):
+    """Score items with exponential time decay applied to a base score."""
+
+    def __init__(self, base_score_key: str = "score", decay_rate: float = 0.01):
+        self.base_score_key = base_score_key
+        self.decay_rate = decay_rate
+
+    def score(self, item: dict) -> float:
+        base = float(item.get(self.base_score_key, 0.0))
+        ts = item.get("timestamp")
+        if not isinstance(ts, datetime):
+            return base
+        age_sec = (datetime.utcnow() - ts).total_seconds()
+        weight = math.exp(-self.decay_rate * age_sec)
+        return base * weight

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ redis==6.1.0
 setuptools==80.8.0
 sympy==1.14.0
 torch==2.7.0
+annoy==1.17.3

--- a/tests/test_ann_index.py
+++ b/tests/test_ann_index.py
@@ -1,0 +1,10 @@
+from core.ann_index import ANNIndex
+
+
+def test_ann_index_basic():
+    idx = ANNIndex(vector_dim=3)
+    idx.add_item("a", [1.0, 0.0, 0.0])
+    idx.add_item("b", [0.0, 1.0, 0.0])
+    idx.build()
+    result = idx.query([0.9, 0.1, 0.0], k=1)
+    assert result[0] == "a"

--- a/tests/test_time_decay_scorer.py
+++ b/tests/test_time_decay_scorer.py
@@ -1,0 +1,10 @@
+from datetime import datetime, timedelta
+from core.time_decay_scorer import TimeDecayScorer
+
+
+def test_time_decay_scorer():
+    scorer = TimeDecayScorer(decay_rate=1.0)
+    now = datetime.utcnow()
+    fresh = {"score": 1.0, "timestamp": now}
+    old = {"score": 1.0, "timestamp": now - timedelta(seconds=10)}
+    assert scorer.score(fresh) > scorer.score(old)


### PR DESCRIPTION
## Summary
- add `TimeDecayScorer` applying exponential decay to context scores
- implement `ANNIndex` wrapper over Annoy for fast nearest neighbor lookups
- expose new utilities via `core.__init__`
- add tests for new scorer and ANN index
- include `annoy` in requirements

## Testing
- `pytest tests/test_ann_index.py tests/test_time_decay_scorer.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a0c44d1d4832ab392e99248b08d44