### PR TITLE
Add JSON-backed FileContextProvider

### DIFF
--- a/docs/dev/architecture.html
+++ b/docs/dev/architecture.html
@@ -52,6 +52,7 @@
   <ul>
     <li><strong>RedisContextProvider:</strong> Stores and retrieves context vectors from Redis.</li>
     <li><strong>FileBasedContextProvider:</strong> Local file storage for development and testing.</li>
+    <li><strong>FileContextProvider:</strong> Persists context entries to a JSON file for offline use.</li>
     <li><strong>SimpleContextProvider:</strong> Minimal in-memory provider for examples.</li>
   </ul>
 

--- a/docs/dev/index.html
+++ b/docs/dev/index.html
@@ -51,7 +51,7 @@
     <h2>2. Architecture</h2>
     <ul>
       <li><strong>Input:</strong> Raw messages or event logs</li>
-      <li><strong>Context Providers:</strong> RedisContextProvider, FileBasedContextProvider, SimpleContextProvider</li>
+      <li><strong>Context Providers:</strong> RedisContextProvider, FileBasedContextProvider, FileContextProvider, SimpleContextProvider</li>
       <li><strong>Core Modules:</strong> Fuser, FuzzyDeduplicator, Categorizer</li>
       <li><strong>Distance Engine:</strong> Vector-based comparison using Cosine/Euclidean metrics</li>
     </ul>
@@ -82,6 +82,7 @@
     <ul>
       <li><code>RedisContextProvider</code>: Uses Redis to store and retrieve context vectors.</li>
       <li><code>FileBasedContextProvider</code>: Simple filesystem-based storage for development or testing.</li>
+      <li><code>FileContextProvider</code>: Persists context entries to a local JSON file for offline demos.</li>
       <li><code>SimpleContextProvider</code>: Minimal in-memory example for quick experiments.</li>
     </ul>
   </div>

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -3,6 +3,7 @@
 
 from .memory_context_provider import MemoryContextProvider
 from .file_based_context_provider import FileBasedContextProvider
+from .file_context_provider import FileContextProvider
 from .redis_context_provider import RedisContextProvider
 from .mock_context_provider import MockContextProvider
 from .simple_context_provider import SimpleContextProvider
@@ -10,6 +11,7 @@ from .simple_context_provider import SimpleContextProvider
 __all__ = [
     "MemoryContextProvider",
     "FileBasedContextProvider",
+    "FileContextProvider",
     "RedisContextProvider",
     "MockContextProvider",
     "SimpleContextProvider",

--- a/providers/file_context_provider.py
+++ b/providers/file_context_provider.py
@@ -1,0 +1,117 @@
+import json
+import os
+import uuid
+from typing import Callable, List, Union
+from datetime import datetime
+
+from objects.context_data import ContextData, SubscriptionHandle
+from objects.context_query import ContextQuery
+
+
+class FileContextProvider:
+    """Persist context entries to a local JSON file."""
+
+    def __init__(self, file_path: str):
+        self.file_path = file_path
+        self.subscribers: dict[SubscriptionHandle, Callable[[ContextData], None]] = {}
+        # Ensure the storage file exists
+        if not os.path.exists(self.file_path):
+            with open(self.file_path, "w", encoding="utf-8") as f:
+                json.dump([], f)
+
+    def _load_entries(self) -> List[dict]:
+        try:
+            with open(self.file_path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return []
+
+    def _save_entries(self, entries: List[dict]):
+        with open(self.file_path, "w", encoding="utf-8") as f:
+            json.dump(entries, f, indent=2)
+
+    def ingest_context(
+        self,
+        payload: dict,
+        timestamp: Union[datetime, None] = None,
+        metadata: Union[dict, None] = None,
+        source_id: str = "file",
+        confidence: float = 1.0,
+    ) -> str:
+        context_id = str(uuid.uuid4())
+        cd = ContextData(
+            payload=payload,
+            timestamp=timestamp or datetime.utcnow(),
+            source_id=source_id,
+            confidence=confidence,
+            metadata=metadata or {},
+            roles=(metadata or {}).get("roles", []),
+            situations=(metadata or {}).get("situations", []),
+            content=(metadata or {}).get("content", ""),
+        )
+        entries = self._load_entries()
+        entries.append(
+            {
+                "id": context_id,
+                "timestamp": cd.timestamp.isoformat(),
+                "source_id": cd.source_id,
+                "confidence": cd.confidence,
+                "metadata": cd.metadata,
+                "data": cd.payload,
+            }
+        )
+        self._save_entries(entries)
+        for cb in self.subscribers.values():
+            cb(cd)
+        return context_id
+
+    def fetch_context(self, query_params: ContextQuery) -> List[ContextData]:
+        entries = self._load_entries()
+        results = []
+        for entry in entries:
+            ts = datetime.fromisoformat(entry["timestamp"])
+            if query_params.time_range[0] <= ts <= query_params.time_range[1]:
+                metadata = entry.get("metadata", {})
+                results.append(
+                    ContextData(
+                        payload=entry.get("data", {}),
+                        timestamp=ts,
+                        source_id=entry.get("source_id", "file"),
+                        metadata=metadata,
+                        roles=metadata.get("roles", []),
+                        situations=metadata.get("situations", []),
+                        content=metadata.get("content", ""),
+                        confidence=entry.get("confidence", 1.0),
+                    )
+                )
+        return results
+
+    def get_context(self, query: ContextQuery) -> List[dict]:
+        raw_contexts = self.fetch_context(query)
+        return [self._to_dict(cd) for cd in raw_contexts]
+
+    def subscribe_context(self, callback: Callable[[ContextData], None]) -> SubscriptionHandle:
+        handle = uuid.uuid4()
+        self.subscribers[handle] = callback
+        return handle
+
+    def publish_context(
+        self,
+        payload: dict,
+        timestamp: Union[datetime, None] = None,
+        metadata: Union[dict, None] = None,
+        source_id: str = "file",
+        confidence: float = 1.0,
+    ):
+        self.ingest_context(payload, timestamp, metadata, source_id, confidence)
+
+    def _to_dict(self, cd: ContextData) -> dict:
+        return {
+            "id": None,
+            "roles": cd.roles,
+            "timestamp": cd.timestamp,
+            "situations": cd.situations,
+            "content": cd.content,
+            "context": cd.payload,
+            "confidence": cd.confidence,
+        }

--- a/tests/test_file_context_provider.py
+++ b/tests/test_file_context_provider.py
@@ -1,0 +1,32 @@
+import unittest
+import tempfile
+import os
+import json
+from datetime import datetime, timedelta
+
+from providers.file_context_provider import FileContextProvider
+from objects.context_query import ContextQuery
+
+
+class TestFileContextProvider(unittest.TestCase):
+    def test_persist_and_fetch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            file_path = os.path.join(tmp, "context.json")
+            provider = FileContextProvider(file_path)
+            now = datetime.utcnow()
+            provider.ingest_context({"value": 1}, timestamp=now)
+            query = ContextQuery(roles=[], time_range=(now - timedelta(seconds=1), now + timedelta(seconds=1)), scope="", data_type="")
+            results = provider.get_context(query)
+            self.assertEqual(len(results), 1)
+            # verify file contents
+            with open(file_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            self.assertEqual(len(data), 1)
+            # reload provider from disk
+            provider2 = FileContextProvider(file_path)
+            results2 = provider2.get_context(query)
+            self.assertEqual(len(results2), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `FileContextProvider` to persist context to a JSON file
- expose the new provider in `providers/__init__.py`
- document `FileContextProvider` in dev docs
- add tests for the new provider

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a0c6f8f2c832a9429b38080abe154