### PR TITLE
Add base provider with broadcast hooks

### DIFF
--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -1,6 +1,7 @@
 
 """Expose available context provider implementations."""
 
+from .base_context_provider import BaseContextProvider
 from .memory_context_provider import MemoryContextProvider
 from .file_based_context_provider import FileBasedContextProvider
 from .redis_context_provider import RedisContextProvider
@@ -8,6 +9,7 @@ from .mock_context_provider import MockContextProvider
 from .simple_context_provider import SimpleContextProvider
 
 __all__ = [
+    "BaseContextProvider",
     "MemoryContextProvider",
     "FileBasedContextProvider",
     "RedisContextProvider",

--- a/providers/base_context_provider.py
+++ b/providers/base_context_provider.py
@@ -1,0 +1,28 @@
+import uuid
+from typing import Callable, Dict, List
+
+from objects.context_data import ContextData, SubscriptionHandle
+
+
+class BaseContextProvider:
+    """Base class providing unified pub/sub and broadcasting."""
+
+    def __init__(self):
+        self.subscribers: Dict[SubscriptionHandle, Callable[[ContextData], None]] = {}
+        self.peers: List["BaseContextProvider"] = []
+
+    def subscribe_context(self, callback: Callable[[ContextData], None]) -> SubscriptionHandle:
+        handle = uuid.uuid4()
+        self.subscribers[handle] = callback
+        return handle
+
+    def add_peer(self, peer: "BaseContextProvider"):
+        if peer is not self and peer not in self.peers:
+            self.peers.append(peer)
+
+    def publish_context(self, data: ContextData, broadcast: bool = True):
+        for cb in self.subscribers.values():
+            cb(data)
+        if broadcast:
+            for peer in self.peers:
+                peer.publish_context(data, broadcast=False)

--- a/providers/file_based_context_provider.py
+++ b/providers/file_based_context_provider.py
@@ -1,15 +1,16 @@
 import json
 import os
 import uuid
-from typing import Optional, Callable, List
+from typing import Optional, List
 from datetime import datetime
-from objects.context_data import ContextData, SubscriptionHandle
+from objects.context_data import ContextData
 from objects.context_query import ContextQuery
+from .base_context_provider import BaseContextProvider
 
-class FileBasedContextProvider:
+class FileBasedContextProvider(BaseContextProvider):
     def __init__(self, folder_path: str):
+        super().__init__()
         self.folder_path = folder_path
-        self.subscribers: dict[SubscriptionHandle, Callable[[ContextData], None]] = {}
 
     def fetch_context(self, query_params: ContextQuery) -> List[ContextData]:
         results = []
@@ -42,15 +43,9 @@ class FileBasedContextProvider:
             "context": cd.payload,
             "confidence": cd.confidence,
         }
-    def subscribe_context(self, callback: Callable[[ContextData], None]) -> SubscriptionHandle:
-        handle = uuid.uuid4()
-        self.subscribers[handle] = callback
-        return handle
-
     def publish_context(self, data: ContextData):
-        # This would be called internally or externally to simulate a live stream
-        for cb in self.subscribers.values():
-            cb(data)
+        """Broadcast file-based context data to subscribers and peers."""
+        super().publish_context(data)
 
 # provider = FileBasedContextProvider("./log_folder")
 #

--- a/providers/redis_context_provider.py
+++ b/providers/redis_context_provider.py
@@ -6,21 +6,22 @@ except ImportError:
     redis = None  # or handle this differently, e.g. raise error on usage
 import uuid
 import json
-from typing import Callable, List
+from typing import List
 from datetime import datetime
 from objects.context_data import ContextData
 from objects.context_query import ContextQuery
+from .base_context_provider import BaseContextProvider
 
 # Assuming ContextQuery and ContextData are already defined as in previous message
 
-class RedisContextProvider:
+class RedisContextProvider(BaseContextProvider):
     def __init__(self, redis_url: str, key_prefix: str = "context:"):
         if redis is None:
             raise ImportError("Redis package is required for RedisContextProvider. "
                               "Install it with `pip install my_package[redis]`.")
+        super().__init__()
         self.redis = redis.Redis.from_url(redis_url, decode_responses=True)
         self.key_prefix = key_prefix
-        self.subscribers: dict[uuid.UUID, Callable[[ContextData], None]] = {}
         # Start pub/sub listener thread
         self.pubsub = self.redis.pubsub()
         self.pubsub.subscribe("context:new")
@@ -86,11 +87,6 @@ class RedisContextProvider:
                 if isinstance(context_id, str):
                     self.push_context(context_id)
 
-    def subscribe_context(self, callback: Callable[[ContextData], None]) -> uuid.UUID:
-        handle = uuid.uuid4()
-        self.subscribers[handle] = callback
-        return handle
-
     def push_context(self, context_id: str):
         """Manually push context by ID to all subscribers"""
         base = f"{self.key_prefix}{context_id}"
@@ -108,8 +104,7 @@ class RedisContextProvider:
                 confidence=confidence,
                 metadata=metadata
             )
-            for cb in self.subscribers.values():
-                cb(context)
+            self.publish_context(context)
         except Exception as e:
             print(f"Failed to push context {context_id}: {e}")
 

--- a/providers/simple_context_provider.py
+++ b/providers/simple_context_provider.py
@@ -1,17 +1,18 @@
 import uuid
 from datetime import datetime
-from typing import Callable, List
+from typing import List
 
 import objects.context_data as ContextData
 import objects.context_query as ContextQuery
+from .base_context_provider import BaseContextProvider
 
 
-class SimpleContextProvider:
+class SimpleContextProvider(BaseContextProvider):
     """Very small in-memory provider for examples and tests."""
 
     def __init__(self):
+        super().__init__()
         self._data: List[ContextData.ContextData] = []
-        self._subscribers: dict[uuid.UUID, Callable[[ContextData.ContextData], None]] = {}
 
     def ingest_context(
         self,
@@ -33,8 +34,7 @@ class SimpleContextProvider:
             content=(metadata or {}).get("content", ""),
         )
         self._data.append(cd)
-        for cb in self._subscribers.values():
-            cb(cd)
+        super().publish_context(cd)
         return context_id
 
     def fetch_context(self, query_params: ContextQuery.ContextQuery) -> List[ContextData.ContextData]:
@@ -47,21 +47,6 @@ class SimpleContextProvider:
     def get_context(self, query: ContextQuery.ContextQuery) -> List[dict]:
         raw = self.fetch_context(query)
         return [self._to_dict(cd) for cd in raw]
-
-    def subscribe_context(self, callback: Callable[[ContextData.ContextData], None]) -> uuid.UUID:
-        handle = uuid.uuid4()
-        self._subscribers[handle] = callback
-        return handle
-
-    def publish_context(
-        self,
-        payload: dict,
-        timestamp: datetime | None = None,
-        metadata: dict | None = None,
-        source_id: str = "simple",
-        confidence: float = 1.0,
-    ):
-        self.ingest_context(payload, timestamp, metadata, source_id, confidence)
 
     def _to_dict(self, cd: ContextData.ContextData) -> dict:
         return {

--- a/tests/test_provider_broadcast.py
+++ b/tests/test_provider_broadcast.py
@@ -1,0 +1,25 @@
+import unittest
+from datetime import datetime
+
+from providers.memory_context_provider import MemoryContextProvider
+from objects.context_data import ContextData
+from objects.context_query import ContextQuery
+
+
+class TestProviderBroadcast(unittest.TestCase):
+    def test_broadcast_across_providers(self):
+        p1 = MemoryContextProvider()
+        p2 = MemoryContextProvider()
+        p1.add_peer(p2)
+
+        received = []
+        p2.subscribe_context(lambda d: received.append(d))
+
+        now = datetime.utcnow()
+        p1.ingest_context({"msg": "hi"}, timestamp=now)
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0].payload, {"msg": "hi"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce `BaseContextProvider` with unified publish/subscribe and peer broadcast
- update built-in providers to inherit from it
- export base provider in package init
- add regression test verifying provider broadcast

## Testing
- `pip install -r requirements.txt` *(failure due to environment, truncated)*
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a0c8eb3e8832aab4c162570645750