### PR TITLE
Add KafkaContextProvider

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,7 +14,7 @@ try:  # pragma: no cover - optional dependency may be missing
 except Exception:  # pragma: no cover - optional dependency may be missing
     AIInferenceEngine = None
 from pipelines import ContextPipeline, FeedbackPipeline
-from providers import MemoryContextProvider
+from providers import MemoryContextProvider, KafkaContextProvider
 from network import NetworkManager, SimpleNetworkMock, ContextBus
 from interfaces import NetworkInterface
 try:
@@ -35,6 +35,7 @@ __all__ = [
     "ContextHookManager",
     "ContextHook",
     "MemoryContextProvider",
+    "KafkaContextProvider",
     "PolicyEvaluator",
     "NetworkManager",
     "SimpleNetworkMock",

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -9,6 +9,7 @@ from .mock_context_provider import MockContextProvider
 from .simple_context_provider import SimpleContextProvider
 from .http_context_provider import HTTPContextProvider
 from .sqlite_context_provider import SQLiteContextProvider
+from .kafka_context_provider import KafkaContextProvider
 
 __all__ = [
     "BaseContextProvider",
@@ -19,4 +20,5 @@ __all__ = [
     "SimpleContextProvider",
     "HTTPContextProvider",
     "SQLiteContextProvider",
+    "KafkaContextProvider",
 ]

--- a/providers/kafka_context_provider.py
+++ b/providers/kafka_context_provider.py
@@ -1,0 +1,134 @@
+import json
+import threading
+import uuid
+from datetime import datetime
+from typing import List, Optional, Union
+
+from core.cache_manager import CacheManager
+from objects.context_data import ContextData
+from objects.context_query import ContextQuery
+from providers.base_context_provider import BaseContextProvider
+
+try:  # pragma: no cover - optional dependency may be missing
+    from kafka import KafkaConsumer
+except Exception:  # pragma: no cover - optional dependency may be missing
+    KafkaConsumer = None
+
+
+class KafkaContextProvider(BaseContextProvider):
+    """Consume context messages from a Kafka topic."""
+
+    def __init__(
+        self,
+        topic: str,
+        bootstrap_servers: str = "localhost:9092",
+        group_id: Optional[str] = None,
+        auto_start: bool = True,
+    ):
+        if KafkaConsumer is None:
+            raise ImportError(
+                "kafka-python package is required for KafkaContextProvider. "
+                "Install it with `pip install ai_context[kafka]`."
+            )
+        super().__init__()
+        self.topic = topic
+        self.bootstrap_servers = bootstrap_servers
+        self.group_id = group_id
+        self.consumer = KafkaConsumer(
+            topic,
+            bootstrap_servers=bootstrap_servers,
+            group_id=group_id,
+            auto_offset_reset="earliest",
+            enable_auto_commit=True,
+        )
+        self.cache = CacheManager()
+        self._thread: Optional[threading.Thread] = None
+        if auto_start:
+            self.start()
+
+    # ------------------------------------------------------------------
+    def start(self):
+        if self._thread:
+            return
+        self._thread = threading.Thread(target=self._consume_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        if self._thread:
+            self.consumer.close()
+            self._thread.join()
+            self._thread = None
+
+    def _consume_loop(self):  # pragma: no cover - requires Kafka
+        for msg in self.consumer:
+            self.ingest_record(msg)
+
+    def ingest_record(self, record):
+        """Process a single Kafka record."""
+        try:
+            value = (
+                record.value.decode()
+                if isinstance(record.value, (bytes, bytearray))
+                else record.value
+            )
+            data = json.loads(value)
+        except Exception:
+            return
+        timestamp = (
+            datetime.fromtimestamp(record.timestamp / 1000.0)
+            if getattr(record, "timestamp", None) is not None
+            else datetime.utcnow()
+        )
+        payload = data.get("payload", data)
+        metadata = data.get("metadata") if isinstance(data, dict) else None
+        self.ingest_context(payload, timestamp=timestamp, metadata=metadata)
+
+    # ------------------------------------------------------------------
+    def ingest_context(
+        self,
+        payload: dict,
+        timestamp: Union[datetime, None] = None,
+        metadata: Union[dict, None] = None,
+        source_id: str = "kafka",
+        confidence: float = 1.0,
+        ttl: Union[int, None] = None,
+    ) -> str:
+        context_id = str(uuid.uuid4())
+        cd = ContextData(
+            payload=payload,
+            timestamp=timestamp or datetime.utcnow(),
+            source_id=source_id,
+            confidence=confidence,
+            metadata=metadata or {},
+            roles=(metadata or {}).get("roles", []),
+            situations=(metadata or {}).get("situations", []),
+            content=(metadata or {}).get("content", ""),
+        )
+        self.cache.set(context_id, cd, ttl)
+        super().publish_context(cd)
+        return context_id
+
+    def fetch_context(self, query_params: ContextQuery) -> List[ContextData]:
+        results = []
+        for key in list(self.cache.cache.keys()):
+            cd = self.cache.get(key)
+            if not cd:
+                continue
+            if query_params.time_range[0] <= cd.timestamp <= query_params.time_range[1]:
+                results.append(cd)
+        return results
+
+    def get_context(self, query: ContextQuery) -> List[dict]:
+        raw = self.fetch_context(query)
+        return [self._to_dict(cd) for cd in raw]
+
+    def _to_dict(self, cd: ContextData) -> dict:
+        return {
+            "id": None,
+            "roles": cd.roles,
+            "timestamp": cd.timestamp,
+            "situations": cd.situations,
+            "content": cd.content,
+            "context": cd.payload,
+            "confidence": cd.confidence,
+        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 
 [project.optional-dependencies]
 redis = ["redis>=6.1.0"]
+kafka = ["kafka-python>=2.0.2"]
 dev = [
     "pytest>=8.3.5",
     "mypy",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy==2.2.6
 pytest==8.3.5
 redis==6.1.0
+kafka-python==2.0.2
 setuptools==80.8.0
 sympy==1.14.0
 torch==2.7.0

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     ],
     extras_require={
         "redis": ["redis>=6.1.0"],
+        "kafka": ["kafka-python>=2.0.2"],
         "dev": [
             "pytest>=8.3.5",
             "mypy",

--- a/tests/test_kafka_context_provider.py
+++ b/tests/test_kafka_context_provider.py
@@ -1,0 +1,46 @@
+import unittest
+from datetime import datetime, timedelta
+
+from objects.context_query import ContextQuery
+
+# patch KafkaConsumer before importing provider
+from providers import kafka_context_provider
+
+class DummyConsumer:
+    def __init__(self, *args, **kwargs):
+        self.messages = []
+
+    def __iter__(self):
+        return iter(self.messages)
+
+    def close(self):
+        pass
+
+class DummyRecord:
+    def __init__(self, value, timestamp=None):
+        self.value = value
+        self.timestamp = timestamp
+
+
+class TestKafkaContextProvider(unittest.TestCase):
+    def test_ingest_record(self):
+        kafka_context_provider.KafkaConsumer = DummyConsumer
+        provider = kafka_context_provider.KafkaContextProvider(
+            "topic", bootstrap_servers="localhost", auto_start=False
+        )
+        now_ms = int(datetime.utcnow().timestamp() * 1000)
+        record = DummyRecord(b'{"payload": {"foo": "bar"}}', now_ms)
+        provider.ingest_record(record)
+        query = ContextQuery(
+            roles=[],
+            time_range=(datetime.utcnow() - timedelta(seconds=1), datetime.utcnow() + timedelta(seconds=1)),
+            scope="",
+            data_type="",
+        )
+        results = provider.get_context(query)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["context"], {"foo": "bar"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `KafkaContextProvider` for ingesting Kafka messages
- expose provider via `__init__` modules
- document optional kafka dependency
- add unit test for Kafka provider
- fix import path in `kafka_context_provider`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install -r requirements.txt` *(failed to finish)*

------
https://chatgpt.com/codex/tasks/task_e_684a1090fd60832aa4fbcd837175e3e6