### PR TITLE
Improve docs directory guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ This modular architecture is designed to evolve alongside AI needs, helping to r
 - AI Inference & Learning Hooks: Modular integration points for custom AI logic and model updates
 - Model Management: Replace, save, and load AI inference models at runtime
 
+## Documentation
+
+Developer guides live in the `docs/` directory. Open
+[docs/dev/index.html](docs/dev/index.html) for usage instructions and
+[docs/theory/index.html](docs/theory/index.html) for design notes.
+
 ## Project Structure
 
 ```plaintext
@@ -47,7 +53,7 @@ This modular architecture is designed to evolve alongside AI needs, helping to r
 ├── objects/
 ├── parser/
 ├── providers/
-├── documentation/
+├── docs/
 │   ├── dev/
 │   └── theory/
 ├── tests/

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Documentation
+
+This project ships developer guides and design notes as static HTML files.
+
+- Open `dev/index.html` for developer-focused documentation.
+- Open `theory/index.html` for theoretical background and architecture notes.
+
+In the future these pages may move to a dedicated docs site (see
+[docs/dev/TECHNICAL_ROADMAP.md](dev/TECHNICAL_ROADMAP.md)).
+

--- a/docs/dev/getting_started.html
+++ b/docs/dev/getting_started.html
@@ -52,8 +52,8 @@
   </ul>
 
   <h2>Step 1: Clone the repository</h2>
-  <pre><code>git clone https://github.com/your_org/contextual-ai.git
-cd contextual-ai</code></pre>
+  <pre><code>git clone https://github.com/Robo-Meister/ai-context-framework.git
+cd ai-context-framework</code></pre>
 
   <h2>Step 2: Create and activate virtual environment</h2>
   <pre><code>python3 -m venv venv


### PR DESCRIPTION
## Summary
- fix outdated path references in README
- add a Documentation section with links to HTML docs
- create a short docs/README for navigation
- update repo link in `getting_started.html`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684aac880610832ab2e0902fb0bc3bc5