### PR TITLE
Improve docs directory guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,31 @@ This modular architecture is designed to evolve alongside AI needs, helping to r
 - AI Inference & Learning Hooks: Modular integration points for custom AI logic and model updates
 - Model Management: Replace, save, and load AI inference models at runtime
 
+## Documentation
+
+Developer guides live in the `docs/` directory. Open
+[docs/dev/index.html](docs/dev/index.html) for usage instructions and
+[docs/theory/index.html](docs/theory/index.html) for design notes. See
+[docs/dev/publishing.html](docs/dev/publishing.html) to learn how to build and
+publish the package.
+
+## Installation
+
+Install the framework directly from PyPI:
+
+```bash
+pip install ai_context
+```
+
+To work on the code locally with optional developer tools, clone the repo and
+install in editable mode:
+
+```bash
+git clone https://github.com/Robo-Meister/ai-context-framework.git
+cd ai-context-framework
+pip install -e .[dev]
+```
+
 ## Project Structure
 
 ```plaintext
@@ -47,7 +72,7 @@ This modular architecture is designed to evolve alongside AI needs, helping to r
 ├── objects/
 ├── parser/
 ├── providers/
-├── documentation/
+├── docs/
 │   ├── dev/
 │   └── theory/
 ├── tests/
@@ -62,7 +87,7 @@ This modular architecture is designed to evolve alongside AI needs, helping to r
 1. Clone the repository:
 
    ```bash
-   https://github.com/Robo-Meister/ai-context-framework.git
+   git clone https://github.com/Robo-Meister/ai-context-framework.git
    cd ai-context-framework
    ```
 2. Create and activate virtual environment (optional but recommended)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# Documentation
+
+This project ships developer guides and design notes as static HTML files.
+
+- Open `dev/index.html` for developer-focused documentation.
+- Open `theory/index.html` for theoretical background and architecture notes.
+- Open `dev/publishing.html` for packaging and distribution instructions.
+
+In the future these pages may move to a dedicated docs site (see
+[docs/dev/TECHNICAL_ROADMAP.md](dev/TECHNICAL_ROADMAP.md)).
+

--- a/docs/dev/api_reference.html
+++ b/docs/dev/api_reference.html
@@ -39,6 +39,7 @@
   <a href="network.html">Network</a>
   <a href="contributing.html">Contributing</a>
   <a href="faq.html">FAQ</a>
+  <a href="publishing.html">Publishing</a>
 </nav>
 
   <h1>📚 API Reference</h1>

--- a/docs/dev/architecture.html
+++ b/docs/dev/architecture.html
@@ -39,6 +39,7 @@
   <a href="network.html">Network</a>
   <a href="contributing.html">Contributing</a>
   <a href="faq.html">FAQ</a>
+  <a href="publishing.html">Publishing</a>
 </nav>
 
   <h1>🏛️ System Architecture</h1>

--- a/docs/dev/contributing.html
+++ b/docs/dev/contributing.html
@@ -39,6 +39,7 @@
   <a href="network.html">Network</a>
   <a href="contributing.html">Contributing</a>
   <a href="faq.html">FAQ</a>
+  <a href="publishing.html">Publishing</a>
 </nav>
 
   <h1>🤝 Contributing to Contextual AI</h1>

--- a/docs/dev/faq.html
+++ b/docs/dev/faq.html
@@ -40,6 +40,7 @@
   <a href="network.html">Network</a>
   <a href="contributing.html">Contributing</a>
   <a href="faq.html">FAQ</a>
+  <a href="publishing.html">Publishing</a>
 </nav>
 
   <h1>❓ Frequently Asked Questions</h1>

--- a/docs/dev/getting_started.html
+++ b/docs/dev/getting_started.html
@@ -38,6 +38,7 @@
   <a href="architecture.html">Architecture</a>
   <a href="contributing.html">Contributing</a>
   <a href="faq.html">FAQ</a>
+  <a href="publishing.html">Publishing</a>
 </nav>
 
   <h1>🚀 Getting Started with Contextual AI</h1>
@@ -52,8 +53,8 @@
   </ul>
 
   <h2>Step 1: Clone the repository</h2>
-  <pre><code>git clone https://github.com/your_org/contextual-ai.git
-cd contextual-ai</code></pre>
+  <pre><code>git clone https://github.com/Robo-Meister/ai-context-framework.git
+cd ai-context-framework</code></pre>
 
   <h2>Step 2: Create and activate virtual environment</h2>
   <pre><code>python3 -m venv venv

--- a/docs/dev/network.html
+++ b/docs/dev/network.html
@@ -38,6 +38,7 @@
   <a href="architecture.html">Architecture</a>
   <a href="contributing.html">Contributing</a>
   <a href="faq.html">FAQ</a>
+  <a href="publishing.html">Publishing</a>
 </nav>
 
 <h1>🔌 Network System</h1>

--- a/docs/dev/publishing.html
+++ b/docs/dev/publishing.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contextual AI - Publishing</title>
+  <style>
+    body {
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      margin: 2rem;
+      line-height: 1.6;
+      max-width: 960px;
+      color: #2c3e50;
+    }
+    h1, h2 {
+      color: #34495e;
+      margin-top: 2rem;
+    }
+    nav a {
+      margin-right: 1rem;
+    }
+    pre, code {
+      background-color: #f4f4f4;
+      padding: 0.2rem 0.4rem;
+    }
+  </style>
+</head>
+<body>
+
+<nav>
+  <a href="index.html">Overview</a>
+  <a href="getting_started.html">Getting Started</a>
+  <a href="api_reference.html">API Reference</a>
+  <a href="architecture.html">Architecture</a>
+  <a href="network.html">Network</a>
+  <a href="contributing.html">Contributing</a>
+  <a href="faq.html">FAQ</a>
+  <a href="publishing.html">Publishing</a>
+</nav>
+
+<h1>📦 Publishing to PyPI</h1>
+<p>This guide outlines the steps to build and upload the package to PyPI.</p>
+
+<h2>1. Install build tools</h2>
+<pre><code>python -m pip install --upgrade build twine</code></pre>
+
+<h2>2. Build distributions</h2>
+<pre><code>python -m build</code></pre>
+
+<h2>3. Upload</h2>
+<p>Upload the generated files in <code>dist/</code> to PyPI:</p>
+<pre><code>twine upload dist/*</code></pre>
+
+<p>Consider uploading to <code>--repository testpypi</code> first to verify the package.</p>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- fix repository cloning command in README
- add Installation section with PyPI/pip instructions
- link to publishing guide in docs and add docs/dev/publishing.html
- mention publishing guide in docs/README
- update nav bar across developer HTML pages to include Publishing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684aac880610832ab2e0902fb0bc3bc5