### PR TITLE
Add pub/sub capabilities to Kafka provider

### DIFF
--- a/docs/dev/TECHNICAL_ROADMAP.md
+++ b/docs/dev/TECHNICAL_ROADMAP.md
@@ -1,8 +1,8 @@
 🔬 Priority 4: Provider Abstractions & Expansion
 
-# 9. KafkaContextProvider (Basic Ingest Only)
+# 9. KafkaContextProvider (Pub/Sub Support)
 ✅ Read from Kafka topic, deserialize, store internally or forward to context engine
-⏳ No pub/sub or feedback loop yet
+✅ Publish ingested context and feedback via Kafka
 🔧 Why: Prepares ground for high-velocity, scalable deployments.
 🚧 Priority 5: Preparation for Extensibility & Learning
 


### PR DESCRIPTION
## Summary
- allow Kafka provider to publish context and feedback
- document Kafka provider pub/sub support
- test Kafka publish behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ac68bbd30832a852962f822a75889