### PR TITLE
Add technical roadmap entry for goal-driven feedback

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -44,3 +44,4 @@ Support for custom vector comparison strategies
 Optional lightweight UI for browsing context history
 Developer guide for custom integrations
 Launch landing page & documentation site (e.g., with mkdocs or docsify)
+Goal-driven feedback loop for adjusting actions toward target context states *(see Technical Roadmap #24)*

--- a/docs/dev/TECHNICAL_ROADMAP.md
+++ b/docs/dev/TECHNICAL_ROADMAP.md
@@ -121,6 +121,9 @@
 ✅ Unified publish/subscribe hooks in BaseContextProvider
 ✅ Broadcast context updates across providers
 🔧 Why: Completes subscription support in Phase 3.
+# 24. Goal-Driven Feedback Loop
+⏳ Analyze history and current actions to nudge context toward user-defined goals
+🔧 Why: Enables proactive course correction toward desired states.
 
 ## 📦 Release & Community Infrastructure
 

--- a/docs/dev/index.html
+++ b/docs/dev/index.html
@@ -118,6 +118,7 @@
       <li>Define a role schema JSON.</li>
       <li>Implement vector normalization.</li>
       <li>Plug in time-decay and approximate nearest neighbor (ANN) search.</li>
+      <li>Plan a goal-driven feedback loop that nudges context toward desired states (<em>see Technical Roadmap #24</em>).</li>
     </ul>
   </div>
 

--- a/docs/theory/architecture.html
+++ b/docs/theory/architecture.html
@@ -32,6 +32,7 @@
       <li><strong>Reinforcement Learning Module:</strong> Improves output selection via feedback on usefulness and alignment.</li>
       <li><strong>Kalman Filter Layer:</strong> Refines estimations over time as new context arrives.</li>
       <li><strong>Mood Layer:</strong> Adds emotional weight based on sentiment or pattern recognition.</li>
+      <li><strong>Goal-Driven Feedback Loop (planned):</strong> Guides actions toward a desired context state based on history (see Technical Roadmap #24).</li>
     </ul>
   </section>
 


### PR DESCRIPTION
## Summary
- cross-reference the goal-driven feedback loop in Roadmap and docs
- add a new technical roadmap item describing the planned loop

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684adc816a8c832aaa3ae4f2939481ac