### PR TITLE
Add sensor pipeline and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ This modular architecture is designed to evolve alongside AI needs, helping to r
 - Pluggable Context Providers: Redis, Kafka, file systems, and more
 - Smart Deduplication: Basic and fuzzy matching to merge similar data
 - Flexible Categorization: Group context by roles and scopes
+- Sublayer Categorization: Nested layers (e.g. environment.camera) allow fine grained
+  weighting and future filter selection. ``Fuser`` automatically merges these
+  dot-separated categories without extra configuration
 - Context Fusion: Aggregate and weigh data for downstream AI
 - Customizable Trust Weights: Adjust context layer weights (role, environment, network, device, location, etc.) to fit your domain
 - Context Memory (with Cache Management): Efficient reuse and invalidation of context data and history data

--- a/src/caiengine/core/categorizer.py
+++ b/src/caiengine/core/categorizer.py
@@ -26,10 +26,24 @@ class Categorizer:
 
         return best_match or "unknown"
 
+    def _flatten(self, ctx: dict, prefix: str = "") -> dict:
+        flat = {}
+        for k, v in ctx.items():
+            if isinstance(v, dict):
+                flat.update(self._flatten(v, prefix + k + "."))
+            else:
+                flat[prefix + k] = v
+        return flat
+
     def compare_layers(self, ctx1: dict, ctx2: dict) -> float:
-        matched_layers = sum(1 for k in ctx1 if ctx1.get(k) == ctx2.get(k))
-        total_layers = len(set(ctx1.keys()) | set(ctx2.keys()))
-        return matched_layers / total_layers if total_layers else 0.0
+        """Return ratio of matching context layers (supports sublayers)."""
+        f1 = self._flatten(ctx1)
+        f2 = self._flatten(ctx2)
+        keys = set(f1.keys()) | set(f2.keys())
+        if not keys:
+            return 0.0
+        matched = sum(1 for k in keys if f1.get(k) == f2.get(k))
+        return matched / len(keys)
 
 # Simple test example
 if __name__ == "__main__":

--- a/src/caiengine/core/fuser.py
+++ b/src/caiengine/core/fuser.py
@@ -4,6 +4,14 @@ from caiengine.common.types.ScopeRoleKey import ScopeRoleKey
 
 
 class Fuser:
+    """Fuse categorized events into aggregated summaries.
+
+    The keys provided by :class:`Categorizer` may include dot-separated
+    sublayer names (for example ``"environment.camera"``). ``Fuser`` treats
+    these like any other key and therefore requires no special handling to
+    merge events across nested categories.
+    """
+
     def fuse(self, categorized_data: Dict[ScopeRoleKey, List[dict]]) -> Dict[ScopeRoleKey, dict]:
         fused_results = {}
 

--- a/src/caiengine/interfaces/context_provider.py
+++ b/src/caiengine/interfaces/context_provider.py
@@ -1,9 +1,20 @@
 class ContextProvider:
-    def __init__(self):
-        # Weights sum to 1.0
-        self.context_weights = {
+    """Basic context provider with trust calculation support.
+
+    The ``context_weights`` structure can contain nested dictionaries to
+    represent sublayers (e.g. ``{"environment": {"camera": 0.1, "temperature":
+    0.08}}``).  This allows callers to provide fine grained context while still
+    falling back to sensible defaults.
+    """
+
+    def __init__(self, context_weights: dict | None = None, layer_types: dict | None = None):
+        # Default weights sum to 1.0
+        self.context_weights = context_weights or {
             "role": 0.18,
-            "environment": 0.18,
+            "environment": {
+                "camera": 0.09,
+                "temperature": 0.09,
+            },
             "network": 0.12,
             "input": 0.12,
             "timeframe": 0.1,
@@ -13,16 +24,42 @@ class ContextProvider:
             "location": 0.06,
         }
 
-    def calculate_trust(self, context_data: dict) -> float:
-        present_sum = 0.0
-        total_weight = sum(self.context_weights.values())
+        # Optional mapping of layer name (or ``layer.sublayer``) to a data type
+        # string.  Not used directly in this class but allows downstream
+        # components to pick appropriate filters/deduplicators.
+        self.layer_types = layer_types or {}
 
-        for layer, weight in self.context_weights.items():
-            presence = 1 if context_data.get(layer) else 0
+    def _iter_weights(self, weights: dict | None = None, prefix: str = ""):
+        if weights is None:
+            weights = self.context_weights
+        for layer, weight in weights.items():
+            if isinstance(weight, dict):
+                yield from self._iter_weights(weight, prefix + layer + ".")
+            else:
+                yield prefix + layer, weight
+
+    def calculate_trust(self, context_data: dict) -> float:
+        """Calculate trust score for provided context data.
+
+        Nested sublayers are handled using dot notation. Missing layers simply
+        contribute ``0`` to the final score.
+        """
+
+        weights = list(self._iter_weights())
+        total_weight = sum(w for _, w in weights)
+        present_sum = 0.0
+
+        for key, weight in weights:
+            if "." in key:
+                layer, sub = key.split(".", 1)
+                presence = 1 if context_data.get(layer, {}).get(sub) else 0
+            else:
+                presence = 1 if context_data.get(key) else 0
             present_sum += weight * presence
 
         return present_sum / total_weight if total_weight else 0.0
 
     def get_adjusted_weight(self, base_weight: float, context_data: dict) -> float:
+        """Return weight scaled by calculated trust."""
         trust_score = self.calculate_trust(context_data)
         return base_weight * trust_score

--- a/src/caiengine/pipelines/__init__.py
+++ b/src/caiengine/pipelines/__init__.py
@@ -1,11 +1,12 @@
 from .context_pipeline import ContextPipeline
 from .vector_pipeline import VectorPipeline
+from .sensor_pipeline import SensorPipeline
 
 try:
     from .feedback_pipeline import FeedbackPipeline
 except ModuleNotFoundError:
     FeedbackPipeline = None
 
-__all__ = ["ContextPipeline", "VectorPipeline"]
+__all__ = ["ContextPipeline", "VectorPipeline", "SensorPipeline"]
 if FeedbackPipeline is not None:
     __all__.insert(1, "FeedbackPipeline")

--- a/src/caiengine/pipelines/sensor_pipeline.py
+++ b/src/caiengine/pipelines/sensor_pipeline.py
@@ -1,0 +1,39 @@
+"""Pipeline specialized for sensor data with nested context layers.
+
+This module provides ``SensorPipeline`` which mirrors
+``ContextPipeline`` but explicitly targets scenarios where sensor or
+environmental data arrives in nested context structures (for example,
+``{"environment": {"camera": "cam1"}}``). It deduplicates events using
+``FuzzyDeduplicator`` and fuses categorized results.
+"""
+
+from collections import defaultdict
+from typing import List
+
+from caiengine.core.categorizer import Categorizer
+from caiengine.core.Deduplicars.fuzzy_deduplicator import FuzzyDeduplicator
+from caiengine.core.fuser import Fuser
+
+
+class SensorPipeline:
+    """Pipeline for processing sensor context data."""
+
+    def __init__(self, context_provider, time_threshold_sec: int = 5,
+                 fuzzy_threshold: float = 0.8, merge_rule=None):
+        self.categorizer = Categorizer(context_provider)
+        self.deduplicator = FuzzyDeduplicator(
+            time_threshold_sec=time_threshold_sec,
+            fuzzy_threshold=fuzzy_threshold,
+            merge_rule=merge_rule,
+        )
+        self.fuser = Fuser()
+
+    def run(self, data_batch: List[dict], candidates: List[dict]):
+        """Deduplicate, categorize and fuse a batch of sensor events."""
+
+        deduped = self.deduplicator.deduplicate(data_batch)
+        categorized = defaultdict(list)
+        for item in deduped:
+            key = self.categorizer.categorize(item, candidates)
+            categorized[key].append(item)
+        return self.fuser.fuse(categorized)

--- a/tests/test_sensor_pipeline.py
+++ b/tests/test_sensor_pipeline.py
@@ -1,0 +1,57 @@
+import unittest
+from datetime import datetime, timedelta
+
+from caiengine.interfaces.context_provider import ContextProvider
+from caiengine.pipelines.sensor_pipeline import SensorPipeline
+
+
+class Provider(ContextProvider):
+    def __init__(self):
+        super().__init__()
+
+
+class TestSensorPipeline(unittest.TestCase):
+    def test_basic_sensor_flow(self):
+        provider = Provider()
+        pipeline = SensorPipeline(provider)
+
+        now = datetime.utcnow()
+        data_batch = [
+            {
+                "timestamp": now,
+                "context": {
+                    "role": "sensor",
+                    "environment": {"camera": "cam1", "temperature": 25},
+                },
+                "content": "cam1 snapshot",
+            },
+            {
+                "timestamp": now + timedelta(seconds=1),
+                "context": {
+                    "role": "sensor",
+                    "environment": {"camera": "cam1", "temperature": 25},
+                },
+                "content": "cam1 snapshot",
+            },
+        ]
+
+        candidates = [
+            {
+                "category": "env",
+                "context": {
+                    "role": "sensor",
+                    "environment": {"camera": "cam1", "temperature": 25},
+                },
+                "base_weight": 1.0,
+            }
+        ]
+
+        result = pipeline.run(data_batch, candidates)
+        self.assertIsInstance(result, dict)
+        self.assertEqual(len(result), 1)
+        fused = next(iter(result.values()))
+        self.assertEqual(fused["count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sublayer_support.py
+++ b/tests/test_sublayer_support.py
@@ -1,0 +1,36 @@
+import unittest
+from caiengine.interfaces.context_provider import ContextProvider
+from caiengine.core.categorizer import Categorizer
+
+class TestSublayerSupport(unittest.TestCase):
+    def test_trust_and_compare_with_sublayers(self):
+        provider = ContextProvider()
+        cat = Categorizer(provider)
+
+        ctx = {
+            "role": "admin",
+            "environment": {
+                "camera": "cam1",
+                "temperature": 25,
+            }
+        }
+        candidate = {
+            "category": "env",
+            "context": {
+                "role": "admin",
+                "environment": {
+                    "camera": "cam1",
+                    "temperature": 25,
+                }
+            },
+            "base_weight": 1.0,
+        }
+
+        trust = provider.calculate_trust(ctx)
+        self.assertGreater(trust, 0)
+
+        score = cat.compare_layers(ctx, candidate["context"])
+        self.assertEqual(score, 1.0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create `SensorPipeline` for nested sensor data
- export `SensorPipeline` from `caiengine.pipelines`
- add functional test verifying deduplication and fusion of sensor context
- clarify that `Fuser` already handles sublayer keys automatically

## Testing
- `pytest tests/test_sensor_pipeline.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ada3761e8832aa8cdadc3715f7bd1