### PR TITLE
Add badges and coverage reporting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,4 +19,6 @@ jobs:
           pip install -e .
       - name: Run tests
         run: |
-          pytest -vv
+          pytest -vv --cov=caiengine --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # CAIEngine
 
+[![Test Suite](https://github.com/Robo-Meister/ai-context-framework/actions/workflows/tests.yml/badge.svg)](https://github.com/Robo-Meister/ai-context-framework/actions/workflows/tests.yml)
+[![codecov](https://codecov.io/gh/Robo-Meister/ai-context-framework/branch/main/graph/badge.svg)](https://codecov.io/gh/Robo-Meister/ai-context-framework)
+
 A Context-Aware AI Engine for decision automation, workflow reasoning, and dynamic task orchestration.
 
 CAIEngine (Context-Aware Intelligence Engine) provides a flexible AI orchestration layer for intelligent automation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ redis = ["redis>=6.1.0"]
 kafka = ["kafka-python>=2.0.2"]
 dev = [
     "pytest>=8.3.5",
+    "pytest-cov>=4.1.0",
     "mypy",
     "black",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy==2.2.6
 pytest==8.3.5
+pytest-cov==4.1.0
 redis==6.1.0
 kafka-python==2.0.2
 setuptools==80.8.0


### PR DESCRIPTION
## Summary
- show GitHub Actions and Codecov badges in README
- install pytest-cov dependency
- add pytest-cov to pyproject `dev` group
- collect coverage in CI and upload to Codecov

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684aec4b4230832ab53ec9a0305d35b9