### PR TITLE
Add helper script for full test requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,12 @@ Developer guides live in the `docs/` directory. Open
    source venv/bin/activate  # Linux/Mac
    venv\Scripts\activate     # Windows
    ```
-3. Install dependencies
+3. Install dependencies and the package in editable mode. The helper script
+   below installs everything needed for the full test suite (including the
+   optional PyTorch components used by some tests).
 
    ```bash
-   pip install -r requirements.txt
+   ./install_test_requirements.sh
    ```
 4. Run the unit tests to verify your setup
 

--- a/install_test_requirements.sh
+++ b/install_test_requirements.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Install dependencies required for running the full test suite, including tests that
+# rely on optional PyTorch components.
+set -e
+python3 -m pip install --upgrade pip
+pip install -r requirements.txt
+pip install -e .


### PR DESCRIPTION
## Summary
- add `install_test_requirements.sh` for easily installing dependencies needed for the whole test suite
- document the new helper script in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aec84a598832a98fa1c0c187f30e9