### PR TITLE
Implement goal feedback loop

### DIFF
--- a/docs/dev/TECHNICAL_ROADMAP.md
+++ b/docs/dev/TECHNICAL_ROADMAP.md
@@ -122,7 +122,7 @@
 ✅ Broadcast context updates across providers
 🔧 Why: Completes subscription support in Phase 3.
 # 24. Goal-Driven Feedback Loop
-⏳ Analyze history and current actions to nudge context toward user-defined goals
+✅ Basic loop with ``SimpleGoalFeedbackStrategy`` nudges actions toward a goal state
 🔧 Why: Enables proactive course correction toward desired states.
 
 ## 📦 Release & Community Infrastructure

--- a/docs/theory/architecture.html
+++ b/docs/theory/architecture.html
@@ -32,7 +32,7 @@
       <li><strong>Reinforcement Learning Module:</strong> Improves output selection via feedback on usefulness and alignment.</li>
       <li><strong>Kalman Filter Layer:</strong> Refines estimations over time as new context arrives.</li>
       <li><strong>Mood Layer:</strong> Adds emotional weight based on sentiment or pattern recognition.</li>
-      <li><strong>Goal-Driven Feedback Loop (planned):</strong> Guides actions toward a desired context state based on history (see Technical Roadmap #24).</li>
+      <li><strong>Goal-Driven Feedback Loop:</strong> Guides actions toward a desired context state based on history (see Technical Roadmap #24).</li>
     </ul>
   </section>
 

--- a/src/caiengine/__init__.py
+++ b/src/caiengine/__init__.py
@@ -18,6 +18,7 @@ from caiengine.providers import MemoryContextProvider, KafkaContextProvider
 from caiengine.network import NetworkManager, SimpleNetworkMock, ContextBus
 from caiengine.interfaces import NetworkInterface
 from caiengine.core.goal_feedback_loop import GoalDrivenFeedbackLoop
+from caiengine.core.goal_strategies import SimpleGoalFeedbackStrategy
 try:
     from . import cli as cli
 except Exception:  # pragma: no cover - fallback when not imported as package
@@ -43,5 +44,6 @@ __all__ = [
     "ContextBus",
     "NetworkInterface",
     "GoalDrivenFeedbackLoop",
+    "SimpleGoalFeedbackStrategy",
     "cli",
 ]

--- a/src/caiengine/core/__init__.py
+++ b/src/caiengine/core/__init__.py
@@ -13,6 +13,7 @@ from .trust_module import TrustModule
 from .time_decay_scorer import TimeDecayScorer
 from .ann_index import ANNIndex
 from .goal_feedback_loop import GoalDrivenFeedbackLoop
+from .goal_strategies import SimpleGoalFeedbackStrategy
 
 __all__ = [
     "CacheManager",
@@ -28,4 +29,5 @@ __all__ = [
     "TimeDecayScorer",
     "ANNIndex",
     "GoalDrivenFeedbackLoop",
+    "SimpleGoalFeedbackStrategy",
 ]

--- a/src/caiengine/core/goal_strategies/__init__.py
+++ b/src/caiengine/core/goal_strategies/__init__.py
@@ -1,0 +1,5 @@
+"""Strategies for adjusting actions toward goal states."""
+
+from .simple_goal_strategy import SimpleGoalFeedbackStrategy
+
+__all__ = ["SimpleGoalFeedbackStrategy"]

--- a/src/caiengine/core/goal_strategies/simple_goal_strategy.py
+++ b/src/caiengine/core/goal_strategies/simple_goal_strategy.py
@@ -1,0 +1,25 @@
+from typing import List, Dict
+
+from caiengine.interfaces.goal_feedback_strategy import GoalFeedbackStrategy
+
+
+class SimpleGoalFeedbackStrategy(GoalFeedbackStrategy):
+    """Naive strategy nudging numeric fields toward a goal state."""
+
+    def suggest_actions(
+        self,
+        history: List[Dict],
+        current_actions: List[Dict],
+        goal_state: Dict,
+    ) -> List[Dict]:
+        last_context = history[-1] if history else {}
+        suggestions = []
+        for action in current_actions:
+            updated = dict(action)
+            for key, target in goal_state.items():
+                if isinstance(target, (int, float)):
+                    current_val = last_context.get(key, 0.0)
+                    delta = target - float(current_val)
+                    updated[key] = float(current_val) + delta * 0.5
+            suggestions.append(updated)
+        return suggestions

--- a/tests/test_goal_feedback_loop.py
+++ b/tests/test_goal_feedback_loop.py
@@ -1,0 +1,52 @@
+from caiengine.core.goal_feedback_loop import GoalDrivenFeedbackLoop
+from caiengine.core.goal_strategies import SimpleGoalFeedbackStrategy
+
+
+def test_goal_feedback_loop_basic():
+    strategy = SimpleGoalFeedbackStrategy()
+    loop = GoalDrivenFeedbackLoop(strategy, goal_state={"progress": 10})
+    history = [{"progress": 0}]
+    actions = [{"progress": 0}]
+    suggested = loop.suggest(history, actions)
+    assert isinstance(suggested, list)
+    assert suggested[0]["progress"] == 5
+
+
+def test_goal_feedback_loop_empty_history():
+    strategy = SimpleGoalFeedbackStrategy()
+    loop = GoalDrivenFeedbackLoop(strategy, goal_state={"progress": 10})
+    suggested = loop.suggest([], [{"progress": 0}])
+    assert suggested[0]["progress"] == 5
+
+
+def test_goal_feedback_loop_multiple_actions():
+    strategy = SimpleGoalFeedbackStrategy()
+    loop = GoalDrivenFeedbackLoop(strategy, goal_state={"progress": 10})
+    history = [{"progress": 4}]
+    actions = [{"progress": 2}, {"progress": 6}]
+    suggested = loop.suggest(history, actions)
+    assert len(suggested) == 2
+    assert all(act["progress"] == 7 for act in suggested)
+
+
+def test_goal_feedback_loop_non_numeric_goal():
+    strategy = SimpleGoalFeedbackStrategy()
+    loop = GoalDrivenFeedbackLoop(
+        strategy, goal_state={"progress": 10, "mood": "happy"}
+    )
+    history = [{"progress": 0, "mood": "sad"}]
+    actions = [{"progress": 0, "mood": "sad"}]
+    suggested = loop.suggest(history, actions)
+    assert suggested[0]["progress"] == 5
+    assert suggested[0]["mood"] == "sad"
+
+
+
+def test_goal_feedback_loop_set_goal_state():
+    strategy = SimpleGoalFeedbackStrategy()
+    loop = GoalDrivenFeedbackLoop(strategy, goal_state={"progress": 4})
+    history = [{"progress": 0}]
+    actions = [{"progress": 0}]
+    assert loop.suggest(history, actions)[0]["progress"] == 2
+    loop.set_goal_state({"progress": 10})
+    assert loop.suggest(history, actions)[0]["progress"] == 5


### PR DESCRIPTION
## Summary
- implement `SimpleGoalFeedbackStrategy` and expose through package API
- update docs about goal driven feedback loop
- add regression test for `GoalDrivenFeedbackLoop`
- expand feedback loop tests with more scenarios

## Testing
- `pytest tests/test_goal_feedback_loop.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684af590dfd0832a8271890fecd53421