### PR TITLE
Add directional layer support for goal strategy

### DIFF
--- a/src/caiengine/core/goal_strategies/simple_goal_strategy.py
+++ b/src/caiengine/core/goal_strategies/simple_goal_strategy.py
@@ -1,10 +1,18 @@
-from typing import List, Dict
+from typing import List, Dict, Iterable
 
 from caiengine.interfaces.goal_feedback_strategy import GoalFeedbackStrategy
 
 
 class SimpleGoalFeedbackStrategy(GoalFeedbackStrategy):
-    """Naive strategy nudging numeric fields toward a goal state."""
+    """Naive strategy nudging numeric fields toward a goal state.
+
+    Optionally supports "one-direction" layers that will never move
+    backwards. This is useful for time-based fields where the goal can
+    only progress forward.
+    """
+
+    def __init__(self, one_direction_layers: Iterable[str] | None = None):
+        self.one_direction_layers = set(one_direction_layers or [])
 
     def suggest_actions(
         self,
@@ -18,8 +26,10 @@ class SimpleGoalFeedbackStrategy(GoalFeedbackStrategy):
             updated = dict(action)
             for key, target in goal_state.items():
                 if isinstance(target, (int, float)):
-                    current_val = last_context.get(key, 0.0)
-                    delta = target - float(current_val)
-                    updated[key] = float(current_val) + delta * 0.5
+                    current_val = float(last_context.get(key, 0.0))
+                    delta = float(target) - current_val
+                    if key in self.one_direction_layers and delta < 0:
+                        delta = 0
+                    updated[key] = current_val + delta * 0.5
             suggestions.append(updated)
         return suggestions

--- a/tests/test_goal_feedback_loop.py
+++ b/tests/test_goal_feedback_loop.py
@@ -50,3 +50,21 @@ def test_goal_feedback_loop_set_goal_state():
     assert loop.suggest(history, actions)[0]["progress"] == 2
     loop.set_goal_state({"progress": 10})
     assert loop.suggest(history, actions)[0]["progress"] == 5
+
+
+def test_goal_feedback_loop_directional_prevents_backward():
+    strategy = SimpleGoalFeedbackStrategy(one_direction_layers=["time"])
+    loop = GoalDrivenFeedbackLoop(strategy, goal_state={"time": 0})
+    history = [{"time": 5}]
+    actions = [{"time": 5}]
+    suggested = loop.suggest(history, actions)
+    assert suggested[0]["time"] == 5
+
+
+def test_goal_feedback_loop_directional_forward():
+    strategy = SimpleGoalFeedbackStrategy(one_direction_layers=["time"])
+    loop = GoalDrivenFeedbackLoop(strategy, goal_state={"time": 10})
+    history = [{"time": 5}]
+    actions = [{"time": 5}]
+    suggested = loop.suggest(history, actions)
+    assert suggested[0]["time"] == 7.5


### PR DESCRIPTION
## Summary
- update `SimpleGoalFeedbackStrategy` to allow directional layers
- prevent backward adjustments for those layers
- add tests for directional goal behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bcfb87108832aa9ddfd90d528a354