### PR TITLE
Add XML, PostgreSQL and MySQL providers

### DIFF
--- a/docs/dev/TECHNICAL_ROADMAP.md
+++ b/docs/dev/TECHNICAL_ROADMAP.md
@@ -112,6 +112,12 @@
 # 21. SQLiteContextProvider (Roadmap Phase 3 - Plugin & Provider Expansion)
 ✅ Lightweight SQL-backed provider for local storage
 ✅ Reuse existing filter and query logic
+# 21a. XMLContextProvider (Roadmap Phase 3 - Plugin & Provider Expansion)
+✅ Simple XML file persistence
+# 21b. PostgresContextProvider (Roadmap Phase 3 - Plugin & Provider Expansion)
+✅ PostgreSQL-backed storage option
+# 21c. MySQLContextProvider (Roadmap Phase 3 - Plugin & Provider Expansion)
+✅ MySQL-backed storage option
 
 # 22. HTTPContextProvider (REST) (Roadmap Phase 3 - Plugin & Provider Expansion)
 ✅ POST/GET endpoints for remote ingestion and retrieval

--- a/docs/dev/index.html
+++ b/docs/dev/index.html
@@ -84,6 +84,9 @@
       <li><code>FileBasedContextProvider</code>: Simple filesystem-based storage for development or testing.</li>
       <li><code>FileContextProvider</code>: Persists context entries to a local JSON file for offline demos.</li>
       <li><code>SimpleContextProvider</code>: Minimal in-memory example for quick experiments.</li>
+      <li><code>XMLContextProvider</code>: Stores context in a simple XML file.</li>
+      <li><code>PostgresContextProvider</code>: Persists context to a PostgreSQL database.</li>
+      <li><code>MySQLContextProvider</code>: Persists context to a MySQL database.</li>
     </ul>
   </div>
 

--- a/src/caiengine/providers/__init__.py
+++ b/src/caiengine/providers/__init__.py
@@ -11,6 +11,9 @@ from .simple_context_provider import SimpleContextProvider
 from .http_context_provider import HTTPContextProvider
 from .sqlite_context_provider import SQLiteContextProvider
 from .kafka_context_provider import KafkaContextProvider
+from .xml_context_provider import XMLContextProvider
+from .postgres_context_provider import PostgresContextProvider
+from .mysql_context_provider import MySQLContextProvider
 
 __all__ = [
     "BaseContextProvider",
@@ -23,4 +26,7 @@ __all__ = [
     "HTTPContextProvider",
     "SQLiteContextProvider",
     "KafkaContextProvider",
+    "XMLContextProvider",
+    "PostgresContextProvider",
+    "MySQLContextProvider",
 ]

--- a/src/caiengine/providers/mysql_context_provider.py
+++ b/src/caiengine/providers/mysql_context_provider.py
@@ -1,0 +1,147 @@
+import json
+import uuid
+from datetime import datetime, timedelta
+from typing import Callable, List, Optional, Union
+
+try:
+    import mysql.connector
+except ImportError:  # pragma: no cover - optional dependency
+    mysql = None
+else:
+    mysql = mysql.connector
+
+from caiengine.objects.context_data import ContextData, SubscriptionHandle
+from caiengine.objects.context_query import ContextQuery
+
+
+class MySQLContextProvider:
+    """MySQL-backed context provider."""
+
+    def __init__(self, **connect_kwargs):
+        if mysql is None:
+            raise ImportError(
+                "mysql-connector-python is required for MySQLContextProvider. Install with `pip install mysql-connector-python`."
+            )
+        self.conn = mysql.connect(**connect_kwargs)
+        self.conn.autocommit = True
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS context (
+                id VARCHAR(255) PRIMARY KEY,
+                payload TEXT,
+                timestamp DATETIME,
+                metadata TEXT,
+                source_id VARCHAR(255),
+                confidence DOUBLE,
+                expiry DATETIME
+            )
+            """
+        )
+        cur.close()
+        self.subscribers: dict[SubscriptionHandle, Callable[[ContextData], None]] = {}
+
+    def ingest_context(
+        self,
+        payload: dict,
+        timestamp: Union[datetime, None] = None,
+        metadata: Union[dict, None] = None,
+        source_id: str = "mysql",
+        confidence: float = 1.0,
+        ttl: Optional[int] = None,
+    ) -> str:
+        context_id = str(uuid.uuid4())
+        ts = timestamp or datetime.utcnow()
+        expiry_ts = ts + timedelta(seconds=ttl) if ttl else None
+        cd = ContextData(
+            payload=payload,
+            timestamp=ts,
+            source_id=source_id,
+            confidence=confidence,
+            metadata=metadata or {},
+            roles=(metadata or {}).get("roles", []),
+            situations=(metadata or {}).get("situations", []),
+            content=(metadata or {}).get("content", ""),
+        )
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO context VALUES (%s, %s, %s, %s, %s, %s, %s)",
+            (
+                context_id,
+                json.dumps(payload),
+                ts,
+                json.dumps(metadata or {}),
+                source_id,
+                confidence,
+                expiry_ts,
+            ),
+        )
+        cur.close()
+        for cb in self.subscribers.values():
+            cb(cd)
+        return context_id
+
+    def fetch_context(self, query_params: ContextQuery) -> List[ContextData]:
+        start = query_params.time_range[0]
+        end = query_params.time_range[1]
+        now = datetime.utcnow()
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            SELECT id, payload, timestamp, metadata, source_id, confidence
+            FROM context
+            WHERE timestamp >= %s AND timestamp <= %s
+              AND (expiry IS NULL OR expiry > %s)
+            """,
+            (start, end, now),
+        )
+        rows = cur.fetchall()
+        cur.close()
+        result: List[ContextData] = []
+        for row in rows:
+            payload = json.loads(row[1])
+            ts = row[2]
+            metadata = json.loads(row[3])
+            cd = ContextData(
+                payload=payload,
+                timestamp=ts,
+                source_id=row[4],
+                confidence=row[5],
+                metadata=metadata,
+                roles=metadata.get("roles", []),
+                situations=metadata.get("situations", []),
+                content=metadata.get("content", ""),
+            )
+            result.append(cd)
+        return result
+
+    def get_context(self, query: ContextQuery) -> List[dict]:
+        raw = self.fetch_context(query)
+        return [self._to_dict(cd) for cd in raw]
+
+    def subscribe_context(self, callback: Callable[[ContextData], None]) -> SubscriptionHandle:
+        handle = uuid.uuid4()
+        self.subscribers[handle] = callback
+        return handle
+
+    def publish_context(
+        self,
+        payload: dict,
+        timestamp: Union[datetime, None] = None,
+        metadata: Union[dict, None] = None,
+        source_id: str = "mysql",
+        confidence: float = 1.0,
+        ttl: Optional[int] = None,
+    ) -> str:
+        return self.ingest_context(payload, timestamp, metadata, source_id, confidence, ttl)
+
+    def _to_dict(self, cd: ContextData) -> dict:
+        return {
+            "id": None,
+            "roles": cd.roles,
+            "timestamp": cd.timestamp,
+            "situations": cd.situations,
+            "content": cd.content,
+            "context": cd.payload,
+            "confidence": cd.confidence,
+        }

--- a/src/caiengine/providers/postgres_context_provider.py
+++ b/src/caiengine/providers/postgres_context_provider.py
@@ -1,0 +1,142 @@
+import json
+import uuid
+from datetime import datetime, timedelta
+from typing import Callable, List, Optional, Union
+
+try:
+    import psycopg2
+except ImportError:  # pragma: no cover - optional dependency
+    psycopg2 = None
+
+from caiengine.objects.context_data import ContextData, SubscriptionHandle
+from caiengine.objects.context_query import ContextQuery
+
+
+class PostgresContextProvider:
+    """PostgreSQL-backed context provider."""
+
+    def __init__(self, dsn: str):
+        if psycopg2 is None:
+            raise ImportError(
+                "psycopg2 is required for PostgresContextProvider. Install with `pip install psycopg2-binary`."
+            )
+        self.conn = psycopg2.connect(dsn)
+        self.conn.autocommit = True
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS context (
+                    id TEXT PRIMARY KEY,
+                    payload TEXT,
+                    timestamp TIMESTAMP,
+                    metadata TEXT,
+                    source_id TEXT,
+                    confidence REAL,
+                    expiry TIMESTAMP
+                )
+                """
+            )
+        self.subscribers: dict[SubscriptionHandle, Callable[[ContextData], None]] = {}
+
+    def ingest_context(
+        self,
+        payload: dict,
+        timestamp: Union[datetime, None] = None,
+        metadata: Union[dict, None] = None,
+        source_id: str = "postgres",
+        confidence: float = 1.0,
+        ttl: Optional[int] = None,
+    ) -> str:
+        context_id = str(uuid.uuid4())
+        ts = timestamp or datetime.utcnow()
+        expiry_ts = ts + timedelta(seconds=ttl) if ttl else None
+        cd = ContextData(
+            payload=payload,
+            timestamp=ts,
+            source_id=source_id,
+            confidence=confidence,
+            metadata=metadata or {},
+            roles=(metadata or {}).get("roles", []),
+            situations=(metadata or {}).get("situations", []),
+            content=(metadata or {}).get("content", ""),
+        )
+        with self.conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO context VALUES (%s, %s, %s, %s, %s, %s, %s)",
+                (
+                    context_id,
+                    json.dumps(payload),
+                    ts,
+                    json.dumps(metadata or {}),
+                    source_id,
+                    confidence,
+                    expiry_ts,
+                ),
+            )
+        for cb in self.subscribers.values():
+            cb(cd)
+        return context_id
+
+    def fetch_context(self, query_params: ContextQuery) -> List[ContextData]:
+        start = query_params.time_range[0]
+        end = query_params.time_range[1]
+        now = datetime.utcnow()
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, payload, timestamp, metadata, source_id, confidence
+                FROM context
+                WHERE timestamp >= %s AND timestamp <= %s
+                  AND (expiry IS NULL OR expiry > %s)
+                """,
+                (start, end, now),
+            )
+            rows = cur.fetchall()
+        result: List[ContextData] = []
+        for row in rows:
+            payload = json.loads(row[1])
+            ts = row[2]
+            metadata = json.loads(row[3])
+            cd = ContextData(
+                payload=payload,
+                timestamp=ts,
+                source_id=row[4],
+                confidence=row[5],
+                metadata=metadata,
+                roles=metadata.get("roles", []),
+                situations=metadata.get("situations", []),
+                content=metadata.get("content", ""),
+            )
+            result.append(cd)
+        return result
+
+    def get_context(self, query: ContextQuery) -> List[dict]:
+        raw = self.fetch_context(query)
+        return [self._to_dict(cd) for cd in raw]
+
+    def subscribe_context(self, callback: Callable[[ContextData], None]) -> SubscriptionHandle:
+        handle = uuid.uuid4()
+        self.subscribers[handle] = callback
+        return handle
+
+    def publish_context(
+        self,
+        payload: dict,
+        timestamp: Union[datetime, None] = None,
+        metadata: Union[dict, None] = None,
+        source_id: str = "postgres",
+        confidence: float = 1.0,
+        ttl: Optional[int] = None,
+    ) -> str:
+        return self.ingest_context(payload, timestamp, metadata, source_id, confidence, ttl)
+
+    def _to_dict(self, cd: ContextData) -> dict:
+        return {
+            "id": None,
+            "roles": cd.roles,
+            "timestamp": cd.timestamp,
+            "situations": cd.situations,
+            "content": cd.content,
+            "context": cd.payload,
+            "confidence": cd.confidence,
+        }

--- a/src/caiengine/providers/xml_context_provider.py
+++ b/src/caiengine/providers/xml_context_provider.py
@@ -1,0 +1,111 @@
+import os
+import uuid
+import json
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from typing import Callable, List, Union
+
+from caiengine.objects.context_data import ContextData, SubscriptionHandle
+from caiengine.objects.context_query import ContextQuery
+
+
+class XMLContextProvider:
+    """Persist context entries to a local XML file."""
+
+    def __init__(self, file_path: str):
+        self.file_path = file_path
+        self.subscribers: dict[SubscriptionHandle, Callable[[ContextData], None]] = {}
+        if not os.path.exists(self.file_path):
+            root = ET.Element("contexts")
+            tree = ET.ElementTree(root)
+            tree.write(self.file_path, encoding="utf-8")
+
+    def _load_root(self) -> ET.Element:
+        tree = ET.parse(self.file_path)
+        return tree.getroot()
+
+    def _save_root(self, root: ET.Element):
+        tree = ET.ElementTree(root)
+        tree.write(self.file_path, encoding="utf-8")
+
+    def ingest_context(
+        self,
+        payload: dict,
+        timestamp: Union[datetime, None] = None,
+        metadata: Union[dict, None] = None,
+        source_id: str = "xml",
+        confidence: float = 1.0,
+    ) -> str:
+        context_id = str(uuid.uuid4())
+        cd = ContextData(
+            payload=payload,
+            timestamp=timestamp or datetime.utcnow(),
+            source_id=source_id,
+            confidence=confidence,
+            metadata=metadata or {},
+            roles=(metadata or {}).get("roles", []),
+            situations=(metadata or {}).get("situations", []),
+            content=(metadata or {}).get("content", ""),
+        )
+        root = self._load_root()
+        entry = ET.SubElement(root, "context", id=context_id)
+        ET.SubElement(entry, "timestamp").text = cd.timestamp.isoformat()
+        ET.SubElement(entry, "source_id").text = cd.source_id
+        ET.SubElement(entry, "confidence").text = str(cd.confidence)
+        ET.SubElement(entry, "metadata").text = json.dumps(cd.metadata)
+        ET.SubElement(entry, "data").text = json.dumps(payload)
+        self._save_root(root)
+        for cb in self.subscribers.values():
+            cb(cd)
+        return context_id
+
+    def fetch_context(self, query_params: ContextQuery) -> List[ContextData]:
+        root = self._load_root()
+        results: List[ContextData] = []
+        for entry in root.findall("context"):
+            ts = datetime.fromisoformat(entry.findtext("timestamp"))
+            if query_params.time_range[0] <= ts <= query_params.time_range[1]:
+                payload = json.loads(entry.findtext("data") or "{}")
+                metadata = json.loads(entry.findtext("metadata") or "{}")
+                cd = ContextData(
+                    payload=payload,
+                    timestamp=ts,
+                    source_id=entry.findtext("source_id") or "xml",
+                    confidence=float(entry.findtext("confidence") or 1.0),
+                    metadata=metadata,
+                    roles=metadata.get("roles", []),
+                    situations=metadata.get("situations", []),
+                    content=metadata.get("content", ""),
+                )
+                results.append(cd)
+        return results
+
+    def get_context(self, query: ContextQuery) -> List[dict]:
+        raw = self.fetch_context(query)
+        return [self._to_dict(cd) for cd in raw]
+
+    def subscribe_context(self, callback: Callable[[ContextData], None]) -> SubscriptionHandle:
+        handle = uuid.uuid4()
+        self.subscribers[handle] = callback
+        return handle
+
+    def publish_context(
+        self,
+        payload: dict,
+        timestamp: Union[datetime, None] = None,
+        metadata: Union[dict, None] = None,
+        source_id: str = "xml",
+        confidence: float = 1.0,
+    ):
+        self.ingest_context(payload, timestamp, metadata, source_id, confidence)
+
+    def _to_dict(self, cd: ContextData) -> dict:
+        return {
+            "id": None,
+            "roles": cd.roles,
+            "timestamp": cd.timestamp,
+            "situations": cd.situations,
+            "content": cd.content,
+            "context": cd.payload,
+            "confidence": cd.confidence,
+        }


### PR DESCRIPTION
## Summary
- implement `XMLContextProvider` to store context in XML
- implement `PostgresContextProvider` using psycopg2
- implement `MySQLContextProvider` using mysql-connector
- expose the new providers
- update docs to mention new providers and roadmap entries

## Testing
- `pytest tests/test_memory_context_provider.py::TestMemoryContextProvider::test_ingest_and_fetch_with_ttl -q`
- `pytest tests/test_sqlite_context_provider.py::TestSQLiteContextProvider::test_ingest_and_fetch_with_ttl -q`


------
https://chatgpt.com/codex/tasks/task_e_684d1b35d9bc832aa6dad79fdfcc3ea5