### PR TITLE
Add configurable pipeline builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,34 @@ categorized = {("", "", ""): results}
 summary = fuser.fuse(categorized)
 print(summary)
 ```
+
+### Configurable Pipeline
+
+The `ConfigurablePipeline` ties providers, policies and optional feedback loops
+into a single object. Simply provide a configuration dictionary and run a batch
+of context items:
+
+```python
+from caiengine.pipelines.configurable_pipeline import ConfigurablePipeline
+from datetime import datetime
+
+config = {
+    "provider": {"type": "memory"},
+    "candidates": [
+        {"category": "foo", "context": {"foo": "bar"}, "base_weight": 1.0}
+    ],
+    "feedback": {"type": "goal", "goal_state": {"progress": 10}},
+}
+
+pipeline = ConfigurablePipeline.from_dict(config)
+data = [{
+    "timestamp": datetime.utcnow(),
+    "context": {"foo": "bar"},
+    "content": "example"
+}]
+result = pipeline.run(data)
+```
+
    
 ## Contributing
 

--- a/src/caiengine/__init__.py
+++ b/src/caiengine/__init__.py
@@ -13,7 +13,7 @@ try:  # pragma: no cover - optional dependency may be missing
     from caiengine.core.ai_inference import AIInferenceEngine
 except Exception:  # pragma: no cover - optional dependency may be missing
     AIInferenceEngine = None
-from caiengine.pipelines import ContextPipeline, FeedbackPipeline
+from caiengine.pipelines import ContextPipeline, FeedbackPipeline, ConfigurablePipeline
 from caiengine.providers import MemoryContextProvider, KafkaContextProvider
 from caiengine.network import NetworkManager, SimpleNetworkMock, ContextBus
 from caiengine.interfaces import NetworkInterface
@@ -31,6 +31,7 @@ __all__ = [
     "AIInferenceEngine",
     "ContextPipeline",
     "FeedbackPipeline",
+    "ConfigurablePipeline",
     "Fuser",
     "ContextManager",
     "DistributedContextManager",

--- a/src/caiengine/pipelines/__init__.py
+++ b/src/caiengine/pipelines/__init__.py
@@ -1,12 +1,13 @@
 from .context_pipeline import ContextPipeline
 from .vector_pipeline import VectorPipeline
 from .sensor_pipeline import SensorPipeline
+from .configurable_pipeline import ConfigurablePipeline
 
 try:
     from .feedback_pipeline import FeedbackPipeline
 except ModuleNotFoundError:
     FeedbackPipeline = None
 
-__all__ = ["ContextPipeline", "VectorPipeline", "SensorPipeline"]
+__all__ = ["ContextPipeline", "VectorPipeline", "SensorPipeline", "ConfigurablePipeline"]
 if FeedbackPipeline is not None:
     __all__.insert(1, "FeedbackPipeline")

--- a/src/caiengine/pipelines/configurable_pipeline.py
+++ b/src/caiengine/pipelines/configurable_pipeline.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from caiengine.pipelines.context_pipeline import ContextPipeline
+from caiengine.pipelines.feedback_pipeline import FeedbackPipeline
+from caiengine.providers import (
+    FileContextProvider,
+    XMLContextProvider,
+    SQLiteContextProvider,
+    MySQLContextProvider,
+    MemoryContextProvider,
+)
+from caiengine.interfaces.context_provider import ContextProvider
+from caiengine.inference.dummy_engine import DummyAIInferenceEngine
+from caiengine.core.trust_module import TrustModule
+from caiengine.core.goal_feedback_loop import GoalDrivenFeedbackLoop
+from caiengine.core.goal_strategies.simple_goal_strategy import SimpleGoalFeedbackStrategy
+from caiengine.policies.simple_policy import SimplePolicyEvaluator
+from caiengine.parser.log_parser import LogParser
+
+
+_PROVIDER_MAP = {
+    "json": FileContextProvider,
+    "xml": XMLContextProvider,
+    "sqlite": SQLiteContextProvider,
+    "mysql": MySQLContextProvider,
+    "memory": lambda **kwargs: ContextProvider(**kwargs),
+}
+
+
+@dataclass
+class ConfigurablePipeline:
+    pipeline: ContextPipeline | FeedbackPipeline
+    provider: Any
+    parser: Any = None
+    candidates: List[Dict] | None = None
+    trust_module: Optional[TrustModule] = None
+    policy: Optional[SimplePolicyEvaluator] = None
+    feedback_loop: Optional[GoalDrivenFeedbackLoop] = None
+
+    @classmethod
+    def from_dict(cls, cfg: Dict[str, Any]) -> "ConfigurablePipeline":
+        prov_cfg = cfg.get("provider", {})
+        prov_type = prov_cfg.get("type", "memory")
+        prov_args = prov_cfg.get("args", {})
+        if prov_type not in _PROVIDER_MAP:
+            raise ValueError(f"Unsupported provider type: {prov_type}")
+        provider_factory = _PROVIDER_MAP[prov_type]
+        if prov_type == "memory" and "context_weights" not in prov_args and "trust_weights" in cfg:
+            prov_args = dict(prov_args)
+            prov_args["context_weights"] = cfg["trust_weights"]
+        provider = provider_factory(**prov_args)
+
+        parser = LogParser() if cfg.get("parser") == "log" else None
+
+        trust_module = None
+        if "trust_weights" in cfg:
+            trust_module = TrustModule(cfg["trust_weights"], parser=parser)
+
+        policy = SimplePolicyEvaluator() if cfg.get("policy") == "simple" else None
+
+        feedback_cfg = cfg.get("feedback") or {}
+        feedback_loop = None
+        if not feedback_cfg:
+            pipeline = ContextPipeline(provider)
+        elif feedback_cfg.get("type") == "complex_nn":
+            from caiengine.core.learning.learning_manager import LearningManager
+            manager = LearningManager(
+                feedback_cfg.get("input_size", 4),
+                hidden_size=feedback_cfg.get("hidden_size", 16),
+                output_size=feedback_cfg.get("output_size", 1),
+                parser=parser,
+            )
+            pipeline = FeedbackPipeline(
+                provider, manager.inference_engine, learning_manager=manager
+            )
+        elif feedback_cfg.get("type") == "goal":
+            engine = DummyAIInferenceEngine()
+            pipeline = FeedbackPipeline(provider, engine)
+            strategy = SimpleGoalFeedbackStrategy(
+                feedback_cfg.get("one_direction_layers", [])
+            )
+            feedback_loop = GoalDrivenFeedbackLoop(
+                strategy, goal_state=feedback_cfg.get("goal_state", {})
+            )
+        else:
+            raise ValueError(f"Unsupported feedback type: {feedback_cfg.get('type')}")
+
+        return cls(
+            pipeline=pipeline,
+            provider=provider,
+            parser=parser,
+            candidates=cfg.get("candidates", []),
+            trust_module=trust_module,
+            policy=policy,
+            feedback_loop=feedback_loop,
+        )
+
+    def run(self, data_batch: List[Any]) -> List[Dict]:
+        processed = []
+        for item in data_batch:
+            if self.parser and isinstance(item, str):
+                item = self.parser.transform(item)
+            processed.append(item)
+
+        results = self.pipeline.run(processed, self.candidates or [])
+
+        if isinstance(results, dict):
+            results = [dict(v, category=k) for k, v in results.items()]
+
+        if self.policy:
+            filtered = []
+            for res in results:
+                ctx = res.get("item", res)
+                outcome = self.policy.evaluate(ctx)
+                if isinstance(outcome, tuple):
+                    passed, pred = outcome
+                else:
+                    passed, pred = outcome, None
+                if passed:
+                    if pred is not None:
+                        res["prediction"] = pred
+                    filtered.append(res)
+            results = filtered
+
+        if self.trust_module:
+            for res in results:
+                ctx = res.get("item", res)
+                presence = {k: bool(ctx.get(k)) for k in self.trust_module.weights}
+                res["trust"] = self.trust_module.calculate_trust(presence)
+
+        if self.feedback_loop:
+            actions = [r.get("prediction", {}) for r in results]
+            suggestions = self.feedback_loop.suggest([], actions)
+            for res, sugg in zip(results, suggestions):
+                res["goal_suggestion"] = sugg
+
+        return results

--- a/src/caiengine/pipelines/context_pipeline.py
+++ b/src/caiengine/pipelines/context_pipeline.py
@@ -9,13 +9,21 @@ from caiengine.core.fuser import Fuser
 class ContextPipeline:
     def __init__(self, context_provider, time_threshold_sec=5, fuzzy_threshold=0.8, merge_rule=None):
         self.categorizer = Categorizer(context_provider)
-        self.deduplicator = FuzzyDeduplicator(time_threshold_sec=time_threshold_sec, fuzzy_threshold=fuzzy_threshold, merge_rule=merge_rule)
+        self.deduplicator = FuzzyDeduplicator(
+            time_threshold_sec=time_threshold_sec,
+            fuzzy_threshold=fuzzy_threshold,
+            merge_rule=merge_rule,
+        )
         self.fuser = Fuser()
 
     def run(self, data_batch: List[dict], candidates: List[dict]):
-        deduped = self.deduplicator.deduplicate(data_batch)
         categorized = defaultdict(list)
-        for item in deduped:
+        for item in data_batch:
             key = self.categorizer.categorize(item, candidates)
             categorized[key].append(item)
-        return self.fuser.fuse(categorized)
+
+        deduped = {
+            key: self.deduplicator.deduplicate(items) for key, items in categorized.items()
+        }
+
+        return self.fuser.fuse(deduped)

--- a/src/caiengine/pipelines/sensor_pipeline.py
+++ b/src/caiengine/pipelines/sensor_pipeline.py
@@ -31,9 +31,13 @@ class SensorPipeline:
     def run(self, data_batch: List[dict], candidates: List[dict]):
         """Deduplicate, categorize and fuse a batch of sensor events."""
 
-        deduped = self.deduplicator.deduplicate(data_batch)
         categorized = defaultdict(list)
-        for item in deduped:
+        for item in data_batch:
             key = self.categorizer.categorize(item, candidates)
             categorized[key].append(item)
-        return self.fuser.fuse(categorized)
+
+        deduped = {
+            key: self.deduplicator.deduplicate(items) for key, items in categorized.items()
+        }
+
+        return self.fuser.fuse(deduped)

--- a/src/caiengine/pipelines/vector_pipeline.py
+++ b/src/caiengine/pipelines/vector_pipeline.py
@@ -23,9 +23,13 @@ class VectorPipeline:
         self.fuser = Fuser()
 
     def run(self, data_batch: List[dict], candidates: List[dict]):
-        deduped = self.deduplicator.deduplicate(data_batch)
         categorized = defaultdict(list)
-        for item in deduped:
+        for item in data_batch:
             key = self.categorizer.categorize(item, candidates)
             categorized[key].append(item)
-        return self.fuser.fuse(categorized)
+
+        deduped = {
+            key: self.deduplicator.deduplicate(items) for key, items in categorized.items()
+        }
+
+        return self.fuser.fuse(deduped)

--- a/tests/test_configurable_pipeline.py
+++ b/tests/test_configurable_pipeline.py
@@ -1,0 +1,37 @@
+import unittest
+from datetime import datetime
+
+from caiengine.pipelines.configurable_pipeline import ConfigurablePipeline
+
+
+class TestConfigurablePipeline(unittest.TestCase):
+    def test_build_and_run_goal(self):
+        cfg = {
+            "provider": {"type": "memory"},
+            "candidates": [
+                {"category": "foo", "context": {"foo": "bar"}, "base_weight": 1.0}
+            ],
+            "policy": "simple",
+            "trust_weights": {"foo": 1.0},
+            "feedback": {"type": "goal", "goal_state": {"progress": 10}},
+        }
+        pipeline = ConfigurablePipeline.from_dict(cfg)
+        now = datetime.utcnow()
+        data_batch = [
+            {
+                "timestamp": now,
+                "context": {"foo": "bar"},
+                "roles": [],
+                "situations": [],
+                "role": "user",
+                "content": "text",
+                "confidence": 1.0,
+            }
+        ]
+        result = pipeline.run(data_batch)
+        self.assertEqual(len(result), 1)
+        self.assertIn("goal_suggestion", result[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `ConfigurablePipeline` to build processing pipelines from a config
- export the new pipeline in the package
- make `FeedbackPipeline` optionaly import torch dependent components
- document new pipeline in README
- add tests for the configurable pipeline
- change deduplication order to run after categorization

## Testing
- `pytest tests/test_context_pipeline.py tests/test_sensor_pipeline.py tests/test_vector_pipeline.py tests/test_feedback_pipeline.py tests/test_configurable_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684d3b00b3e0832aa03467ee6ddabcb9