### PR TITLE
Implement CSVContextProvider

### DIFF
--- a/docs/dev/index.html
+++ b/docs/dev/index.html
@@ -83,6 +83,7 @@
       <li><code>RedisContextProvider</code>: Uses Redis to store and retrieve context vectors.</li>
       <li><code>FileBasedContextProvider</code>: Simple filesystem-based storage for development or testing.</li>
       <li><code>FileContextProvider</code>: Persists context entries to a local JSON file for offline demos.</li>
+      <li><code>CSVContextProvider</code>: Stores context entries in a CSV file.</li>
       <li><code>SimpleContextProvider</code>: Minimal in-memory example for quick experiments.</li>
       <li><code>XMLContextProvider</code>: Stores context in a simple XML file.</li>
       <li><code>PostgresContextProvider</code>: Persists context to a PostgreSQL database.</li>

--- a/src/caiengine/providers/__init__.py
+++ b/src/caiengine/providers/__init__.py
@@ -10,6 +10,7 @@ from .mock_context_provider import MockContextProvider
 from .simple_context_provider import SimpleContextProvider
 from .http_context_provider import HTTPContextProvider
 from .sqlite_context_provider import SQLiteContextProvider
+from .csv_context_provider import CSVContextProvider
 from .kafka_context_provider import KafkaContextProvider
 from .xml_context_provider import XMLContextProvider
 from .postgres_context_provider import PostgresContextProvider
@@ -25,6 +26,7 @@ __all__ = [
     "SimpleContextProvider",
     "HTTPContextProvider",
     "SQLiteContextProvider",
+    "CSVContextProvider",
     "KafkaContextProvider",
     "XMLContextProvider",
     "PostgresContextProvider",

--- a/src/caiengine/providers/csv_context_provider.py
+++ b/src/caiengine/providers/csv_context_provider.py
@@ -1,0 +1,136 @@
+import csv
+import os
+import json
+import uuid
+from datetime import datetime
+from typing import Callable, List, Union
+
+from caiengine.objects.context_data import ContextData, SubscriptionHandle
+from caiengine.objects.context_query import ContextQuery
+from .base_context_provider import BaseContextProvider
+
+
+class CSVContextProvider(BaseContextProvider):
+    """Persist context entries to a local CSV file."""
+
+    def __init__(self, file_path: str):
+        super().__init__()
+        self.file_path = file_path
+        if not os.path.exists(self.file_path):
+            with open(self.file_path, "w", newline="", encoding="utf-8") as f:
+                writer = csv.writer(f)
+                writer.writerow([
+                    "id",
+                    "timestamp",
+                    "source_id",
+                    "confidence",
+                    "metadata",
+                    "data",
+                ])
+
+    def _write_row(self, row: dict):
+        with open(self.file_path, "a", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(
+                [
+                    row["id"],
+                    row["timestamp"],
+                    row["source_id"],
+                    row["confidence"],
+                    row["metadata"],
+                    row["data"],
+                ]
+            )
+
+    def _read_rows(self) -> List[dict]:
+        if not os.path.exists(self.file_path):
+            return []
+        with open(self.file_path, "r", newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            return list(reader)
+
+    def ingest_context(
+        self,
+        payload: dict,
+        timestamp: Union[datetime, None] = None,
+        metadata: Union[dict, None] = None,
+        source_id: str = "csv",
+        confidence: float = 1.0,
+    ) -> str:
+        context_id = str(uuid.uuid4())
+        ts = timestamp or datetime.utcnow()
+        meta = metadata or {}
+        cd = ContextData(
+            payload=payload,
+            timestamp=ts,
+            source_id=source_id,
+            confidence=confidence,
+            metadata=meta,
+            roles=meta.get("roles", []),
+            situations=meta.get("situations", []),
+            content=meta.get("content", ""),
+        )
+        self._write_row(
+            {
+                "id": context_id,
+                "timestamp": ts.isoformat(),
+                "source_id": source_id,
+                "confidence": confidence,
+                "metadata": json.dumps(meta),
+                "data": json.dumps(payload),
+            }
+        )
+        super().publish_context(cd)
+        return context_id
+
+    def fetch_context(self, query_params: ContextQuery) -> List[ContextData]:
+        rows = self._read_rows()
+        results: List[ContextData] = []
+        for row in rows:
+            try:
+                ts = datetime.fromisoformat(row["timestamp"])
+            except Exception:
+                continue
+            if query_params.time_range[0] <= ts <= query_params.time_range[1]:
+                metadata = json.loads(row.get("metadata", "{}"))
+                payload = json.loads(row.get("data", "{}"))
+                cd = ContextData(
+                    payload=payload,
+                    timestamp=ts,
+                    source_id=row.get("source_id", "csv"),
+                    confidence=float(row.get("confidence", 1.0)),
+                    metadata=metadata,
+                    roles=metadata.get("roles", []),
+                    situations=metadata.get("situations", []),
+                    content=metadata.get("content", ""),
+                )
+                results.append(cd)
+        return results
+
+    def get_context(self, query: ContextQuery) -> List[dict]:
+        raw = self.fetch_context(query)
+        return [self._to_dict(cd) for cd in raw]
+
+    def publish_context(
+        self,
+        payload: dict,
+        timestamp: Union[datetime, None] = None,
+        metadata: Union[dict, None] = None,
+        source_id: str = "csv",
+        confidence: float = 1.0,
+    ) -> str:
+        return self.ingest_context(payload, timestamp, metadata, source_id, confidence)
+
+    def subscribe_context(self, callback: Callable[[ContextData], None]) -> SubscriptionHandle:
+        return super().subscribe_context(callback)
+
+    def _to_dict(self, cd: ContextData) -> dict:
+        return {
+            "id": None,
+            "roles": cd.roles,
+            "timestamp": cd.timestamp,
+            "situations": cd.situations,
+            "content": cd.content,
+            "context": cd.payload,
+            "confidence": cd.confidence,
+        }

--- a/tests/test_csv_context_provider.py
+++ b/tests/test_csv_context_provider.py
@@ -1,0 +1,35 @@
+import unittest
+import tempfile
+import os
+from datetime import datetime, timedelta
+
+from caiengine.providers.csv_context_provider import CSVContextProvider
+from caiengine.objects.context_query import ContextQuery
+
+
+class TestCSVContextProvider(unittest.TestCase):
+    def test_persist_and_fetch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            file_path = os.path.join(tmp, "context.csv")
+            provider = CSVContextProvider(file_path)
+            now = datetime.utcnow()
+            provider.ingest_context({"value": 1}, timestamp=now)
+            query = ContextQuery(
+                roles=[],
+                time_range=(now - timedelta(seconds=1), now + timedelta(seconds=1)),
+                scope="",
+                data_type="",
+            )
+            results = provider.get_context(query)
+            self.assertEqual(len(results), 1)
+            # verify file contents
+            with open(file_path, "r", encoding="utf-8") as f:
+                lines = f.readlines()
+            self.assertEqual(len(lines), 2)  # header + 1 entry
+            provider2 = CSVContextProvider(file_path)
+            results2 = provider2.get_context(query)
+            self.assertEqual(len(results2), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `CSVContextProvider` for persisting context data in CSV files
- export the new provider in the provider package
- document the provider in the developer docs
- test the provider's basic functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688640e7c11c832a8ee4be605e4831bb