### PR TITLE
Add personality-based goal strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This modular architecture is designed to evolve alongside AI needs, helping to r
 - Distributed Context Sync & Network Communication: Synchronize context state across nodes and trigger actions over the network. Includes `NetworkManager`, `SimpleNetworkMock`, `DistributedContextManager`, `ContextBus`, and network-aware hooks. See `docs/dev/network.html` for details.
 - AI Inference & Learning Hooks: Modular integration points for custom AI logic and model updates
 - Model Management: Replace, save, and load AI inference models at runtime
-- Goal-Driven Feedback Loop: Nudge actions toward user-defined goals via strategies like ``SimpleGoalFeedbackStrategy``
+- Goal-Driven Feedback Loop: Nudge actions toward user-defined goals via strategies like ``SimpleGoalFeedbackStrategy`` or ``PersonalityGoalFeedbackStrategy`` for NPC traits
 
 ## Documentation
 

--- a/src/caiengine/__init__.py
+++ b/src/caiengine/__init__.py
@@ -18,7 +18,10 @@ from caiengine.providers import MemoryContextProvider, KafkaContextProvider
 from caiengine.network import NetworkManager, SimpleNetworkMock, ContextBus
 from caiengine.interfaces import NetworkInterface
 from caiengine.core.goal_feedback_loop import GoalDrivenFeedbackLoop
-from caiengine.core.goal_strategies import SimpleGoalFeedbackStrategy
+from caiengine.core.goal_strategies import (
+    SimpleGoalFeedbackStrategy,
+    PersonalityGoalFeedbackStrategy,
+)
 try:
     from . import cli as cli
 except Exception:  # pragma: no cover - fallback when not imported as package
@@ -47,5 +50,6 @@ __all__ = [
     "NetworkInterface",
     "GoalDrivenFeedbackLoop",
     "SimpleGoalFeedbackStrategy",
+    "PersonalityGoalFeedbackStrategy",
     "cli",
 ]

--- a/src/caiengine/core/__init__.py
+++ b/src/caiengine/core/__init__.py
@@ -13,7 +13,10 @@ from .trust_module import TrustModule
 from .time_decay_scorer import TimeDecayScorer
 from .ann_index import ANNIndex
 from .goal_feedback_loop import GoalDrivenFeedbackLoop
-from .goal_strategies import SimpleGoalFeedbackStrategy
+from .goal_strategies import (
+    SimpleGoalFeedbackStrategy,
+    PersonalityGoalFeedbackStrategy,
+)
 
 __all__ = [
     "CacheManager",
@@ -30,4 +33,5 @@ __all__ = [
     "ANNIndex",
     "GoalDrivenFeedbackLoop",
     "SimpleGoalFeedbackStrategy",
+    "PersonalityGoalFeedbackStrategy",
 ]

--- a/src/caiengine/core/goal_strategies/__init__.py
+++ b/src/caiengine/core/goal_strategies/__init__.py
@@ -1,5 +1,6 @@
 """Strategies for adjusting actions toward goal states."""
 
 from .simple_goal_strategy import SimpleGoalFeedbackStrategy
+from .personality_goal_strategy import PersonalityGoalFeedbackStrategy
 
-__all__ = ["SimpleGoalFeedbackStrategy"]
+__all__ = ["SimpleGoalFeedbackStrategy", "PersonalityGoalFeedbackStrategy"]

--- a/src/caiengine/core/goal_strategies/personality_goal_strategy.py
+++ b/src/caiengine/core/goal_strategies/personality_goal_strategy.py
@@ -1,0 +1,37 @@
+from typing import Iterable, List, Dict
+
+from caiengine.interfaces.goal_feedback_strategy import GoalFeedbackStrategy
+
+class PersonalityGoalFeedbackStrategy(GoalFeedbackStrategy):
+    """Adjust suggestions based on a simple NPC personality trait."""
+
+    PERSONALITY_FACTOR = {
+        "cautious": 0.25,
+        "neutral": 0.5,
+        "aggressive": 0.75,
+    }
+
+    def __init__(self, personality: str = "neutral", one_direction_layers: Iterable[str] | None = None):
+        self.personality = personality.lower()
+        self.one_direction_layers = set(one_direction_layers or [])
+
+    def suggest_actions(
+        self,
+        history: List[Dict],
+        current_actions: List[Dict],
+        goal_state: Dict,
+    ) -> List[Dict]:
+        factor = self.PERSONALITY_FACTOR.get(self.personality, 0.5)
+        last_context = history[-1] if history else {}
+        suggestions = []
+        for action in current_actions:
+            updated = dict(action)
+            for key, target in goal_state.items():
+                if isinstance(target, (int, float)):
+                    current_val = float(last_context.get(key, 0.0))
+                    delta = float(target) - current_val
+                    if key in self.one_direction_layers and delta < 0:
+                        delta = 0
+                    updated[key] = current_val + delta * factor
+            suggestions.append(updated)
+        return suggestions

--- a/tests/test_personality_goal_strategy.py
+++ b/tests/test_personality_goal_strategy.py
@@ -1,0 +1,16 @@
+from caiengine.core.goal_feedback_loop import GoalDrivenFeedbackLoop
+from caiengine.core.goal_strategies import PersonalityGoalFeedbackStrategy
+
+
+def test_personality_aggressive():
+    strategy = PersonalityGoalFeedbackStrategy(personality="aggressive")
+    loop = GoalDrivenFeedbackLoop(strategy, goal_state={"progress": 10})
+    result = loop.suggest([{"progress": 0}], [{"progress": 0}])
+    assert result[0]["progress"] == 7.5
+
+
+def test_personality_cautious():
+    strategy = PersonalityGoalFeedbackStrategy(personality="cautious")
+    loop = GoalDrivenFeedbackLoop(strategy, goal_state={"progress": 8})
+    result = loop.suggest([{"progress": 4}], [{"progress": 4}])
+    assert result[0]["progress"] == 5


### PR DESCRIPTION
## Summary
- add `PersonalityGoalFeedbackStrategy` for NPC traits
- expose new strategy from package
- document usage in README
- test aggressive and cautious personalities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68864fe30544832a953d64a10e46b8a3