### PR TITLE
Add CAI_ENGINE_ENDPOINT placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example CAIEngine environment variables
+CAI_ENGINE_ENDPOINT=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ Developer guides live in the `docs/` directory. Open
 
 You can now start implementing your own `ContextProvider` or test the built-in ones.
 
+### Environment Variables
+
+Copy `.env.example` to `.env` and adjust the values as needed. The file includes
+settings used by helpers and integration services.
+
+- `CAI_ENGINE_ENDPOINT` – Base URL for services (like `npcAiService.js`) that
+  communicate with the CAIEngine API.
+
 ### Loading Example Contexts
 
 ```python


### PR DESCRIPTION
## Summary
- add `.env.example` with `CAI_ENGINE_ENDPOINT` placeholder
- document the environment variable in README

## Testing
- `pytest -q` *(fails: 32 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68865657897c832abc2e726421721861