### PR TITLE
Add npcContextService tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,7 @@ Pipfile.lock
 
 # Redis dump files (if you run redis locally)
 dump.rdb
+
+# Node.js
+Server/node_modules/
+Server/package-lock.json

--- a/Server/npcContextService.js
+++ b/Server/npcContextService.js
@@ -1,0 +1,20 @@
+const historyMap = new Map();
+
+function addEntry(npcId, entry) {
+  if (!npcId) return; // ignore invalid ids
+  if (!historyMap.has(npcId)) {
+    historyMap.set(npcId, []);
+  }
+  historyMap.get(npcId).push(entry);
+}
+
+function getRecentHistory(npcId, limit = 10) {
+  const history = historyMap.get(npcId) || [];
+  return history.slice(-limit);
+}
+
+function clearHistory() {
+  historyMap.clear();
+}
+
+module.exports = { addEntry, getRecentHistory, clearHistory };

--- a/Server/package.json
+++ b/Server/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "npc-context-service",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.4"
+  }
+}

--- a/Server/tests/npcContextService.test.js
+++ b/Server/tests/npcContextService.test.js
@@ -1,0 +1,45 @@
+const { addEntry, getRecentHistory, clearHistory } = require('../npcContextService');
+
+describe('npcContextService', () => {
+  beforeEach(() => {
+    clearHistory();
+  });
+
+  test('addEntry and getRecentHistory store and retrieve entries', () => {
+    addEntry('npc1', { text: 'hello' });
+    addEntry('npc1', { text: 'world' });
+
+    const history = getRecentHistory('npc1');
+    expect(history).toHaveLength(2);
+    expect(history[0]).toEqual({ text: 'hello' });
+    expect(history[1]).toEqual({ text: 'world' });
+  });
+
+  test('getRecentHistory respects limit', () => {
+    addEntry('npc2', 'a');
+    addEntry('npc2', 'b');
+    addEntry('npc2', 'c');
+
+    const history = getRecentHistory('npc2', 2);
+    expect(history).toEqual(['b', 'c']);
+  });
+
+  test('getRecentHistory returns empty array when no history', () => {
+    const history = getRecentHistory('unknown');
+    expect(history).toEqual([]);
+  });
+
+  test('entries are kept separate per NPC', () => {
+    addEntry('npc1', 1);
+    addEntry('npc2', 2);
+    const h1 = getRecentHistory('npc1');
+    const h2 = getRecentHistory('npc2');
+    expect(h1).toEqual([1]);
+    expect(h2).toEqual([2]);
+  });
+
+  test('addEntry ignores empty npcId', () => {
+    addEntry('', 'x');
+    expect(getRecentHistory('')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- implement a simple NPC context service for JS tests
- add Jest-based tests covering addEntry and getRecentHistory
- ignore Node build artifacts

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68865656f02c832a96996deb4051f5e5