### PR TITLE
Add personality support to CAIBridge

### DIFF
--- a/Server/data/npcs.json
+++ b/Server/data/npcs.json
@@ -1,0 +1,4 @@
+{
+  "npc1": {"personality": "aggressive"},
+  "npc2": {"personality": "cautious"}
+}

--- a/Server/src/services/npcAiService.js
+++ b/Server/src/services/npcAiService.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+const npcPath = path.join(__dirname, '../../data/npcs.json');
+let npcData = {};
+
+function loadNpcData() {
+  try {
+    const raw = fs.readFileSync(npcPath, 'utf-8');
+    npcData = JSON.parse(raw);
+  } catch (err) {
+    npcData = {};
+  }
+}
+
+loadNpcData();
+
+function getPersonality(id) {
+  return (npcData[id] && npcData[id].personality) || null;
+}
+
+async function sendRequest(npcId, context) {
+  const personality = getPersonality(npcId);
+  const payload = { npcId, context, personality };
+  // Here we'd normally forward payload to the Python service via HTTP
+  return payload;
+}
+
+module.exports = { sendRequest, loadNpcData };

--- a/src/caiengine/__init__.py
+++ b/src/caiengine/__init__.py
@@ -22,6 +22,7 @@ from caiengine.core.goal_strategies import (
     SimpleGoalFeedbackStrategy,
     PersonalityGoalFeedbackStrategy,
 )
+from caiengine.cai_bridge import CAIBridge
 try:
     from . import cli as cli
 except Exception:  # pragma: no cover - fallback when not imported as package
@@ -51,5 +52,6 @@ __all__ = [
     "GoalDrivenFeedbackLoop",
     "SimpleGoalFeedbackStrategy",
     "PersonalityGoalFeedbackStrategy",
+    "CAIBridge",
     "cli",
 ]

--- a/src/caiengine/cai_bridge.py
+++ b/src/caiengine/cai_bridge.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import List, Dict, Optional
+
+from caiengine.core.goal_feedback_loop import GoalDrivenFeedbackLoop
+from caiengine.core.goal_strategies import (
+    SimpleGoalFeedbackStrategy,
+    PersonalityGoalFeedbackStrategy,
+)
+
+
+class CAIBridge:
+    """Simple bridge for running goal feedback with optional NPC personalities."""
+
+    def __init__(
+        self,
+        goal_state: Optional[Dict] = None,
+        personality: Optional[str] = None,
+        one_direction_layers: Optional[List[str]] | None = None,
+    ) -> None:
+        self.goal_state = goal_state or {}
+        strategy = None
+        if personality:
+            strategy = PersonalityGoalFeedbackStrategy(
+                personality=personality,
+                one_direction_layers=one_direction_layers or [],
+            )
+        elif one_direction_layers is not None:
+            strategy = SimpleGoalFeedbackStrategy(one_direction_layers)
+
+        self.feedback_loop = (
+            GoalDrivenFeedbackLoop(strategy, goal_state=self.goal_state)
+            if strategy
+            else None
+        )
+
+    def suggest(self, history: List[Dict], actions: List[Dict]) -> List[Dict]:
+        if self.feedback_loop:
+            return self.feedback_loop.suggest(history, actions)
+        return actions

--- a/tests/test_cai_bridge.py
+++ b/tests/test_cai_bridge.py
@@ -1,0 +1,11 @@
+from caiengine.cai_bridge import CAIBridge
+
+
+def test_cai_bridge_personality_changes_suggestions():
+    history = [{"progress": 0}]
+    actions = [{"progress": 0}]
+    aggressive = CAIBridge(goal_state={"progress": 10}, personality="aggressive")
+    cautious = CAIBridge(goal_state={"progress": 10}, personality="cautious")
+    result_aggressive = aggressive.suggest(history, actions)[0]["progress"]
+    result_cautious = cautious.suggest(history, actions)[0]["progress"]
+    assert result_aggressive > result_cautious


### PR DESCRIPTION
## Summary
- create CAIBridge to use PersonalityGoalFeedbackStrategy when a trait is supplied
- export CAIBridge in package
- add npc personality support in npcAiService.js and sample npc data
- unit test verifying personality alters suggestions

## Testing
- `./install_test_requirements.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688656545c54832aa47f47a7800126c8