### PR TITLE
Add CAIEngine REST service and JS client

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ Developer guides live in the `docs/` directory. Open
 
 You can now start implementing your own `ContextProvider` or test the built-in ones.
 
+### Starting the Service
+
+Launch a small REST server exposing the `HTTPContextProvider` and goal feedback loop:
+
+```bash
+python -m caiengine.service
+```
+
+The server binds to `0.0.0.0:8080` by default. Set `CAI_ENGINE_ENDPOINT` in your application to this URL to reuse the running service instead of spawning `cai_bridge.py` repeatedly.
+
+
 ### Loading Example Contexts
 
 ```python

--- a/Server/src/services/npcAiService.js
+++ b/Server/src/services/npcAiService.js
@@ -1,0 +1,74 @@
+const { spawn } = require('child_process');
+const http = require('http');
+const https = require('https');
+const { URL } = require('url');
+
+const endpoint = process.env.CAI_ENGINE_ENDPOINT;
+
+function httpRequest(url, data) {
+  const opts = new URL(url);
+  const lib = opts.protocol === 'https:' ? https : http;
+  const options = {
+    hostname: opts.hostname,
+    port: opts.port,
+    path: opts.pathname + opts.search,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  };
+  return new Promise((resolve, reject) => {
+    const req = lib.request(options, (res) => {
+      let body = '';
+      res.on('data', (chunk) => (body += chunk));
+      res.on('end', () => {
+        if (res.statusCode >= 200 && res.statusCode < 300) {
+          try {
+            resolve(JSON.parse(body));
+          } catch (e) {
+            reject(e);
+          }
+        } else {
+          reject(new Error('Request failed: ' + res.statusCode));
+        }
+      });
+    });
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+async function suggest(history, actions, goalState) {
+  if (endpoint) {
+    const payload = JSON.stringify({
+      history: history || [],
+      current_actions: actions || [],
+      goal_state: goalState,
+    });
+    return httpRequest(new URL('/suggest', endpoint).toString(), payload);
+  }
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn('python3', ['cai_bridge.py']);
+    let out = '';
+    proc.stdout.on('data', (d) => (out += d));
+    proc.stderr.on('data', (d) => console.error(d.toString()));
+    proc.on('close', (code) => {
+      if (code !== 0) return reject(new Error('cai_bridge.py failed'));
+      try {
+        resolve(JSON.parse(out));
+      } catch (e) {
+        reject(e);
+      }
+    });
+    proc.stdin.write(
+      JSON.stringify({
+        history: history || [],
+        current_actions: actions || [],
+        goal_state: goalState,
+      })
+    );
+    proc.stdin.end();
+  });
+}
+
+module.exports = { suggest };

--- a/src/caiengine/service.py
+++ b/src/caiengine/service.py
@@ -1,0 +1,87 @@
+import argparse
+import json
+from http.server import HTTPServer
+import threading
+
+from caiengine.providers.http_context_provider import HTTPContextProvider
+from caiengine.core.goal_feedback_loop import GoalDrivenFeedbackLoop
+from caiengine.core.goal_strategies import SimpleGoalFeedbackStrategy
+
+
+class CAIService:
+    """Combined HTTP service exposing context and feedback endpoints."""
+
+    def __init__(self, host: str = "0.0.0.0", port: int = 8080):
+        self.host = host
+        self.port = port
+        self.provider = HTTPContextProvider(host=host, port=port)
+        self.feedback_loop = GoalDrivenFeedbackLoop(SimpleGoalFeedbackStrategy())
+        self._server: HTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def _make_handler(self):
+        base_handler = self.provider._make_handler()
+        service = self
+
+        class Handler(base_handler):
+            def do_POST(self):
+                if self.path == "/suggest":
+                    length = int(self.headers.get("Content-Length", "0"))
+                    body = self.rfile.read(length)
+                    try:
+                        payload = json.loads(body)
+                    except json.JSONDecodeError:
+                        self.send_response(400)
+                        self.end_headers()
+                        return
+
+                    history = payload.get("history", [])
+                    current_actions = payload.get("current_actions", [])
+                    goal_state = payload.get("goal_state")
+                    if goal_state is not None:
+                        service.feedback_loop.set_goal_state(goal_state)
+                    result = service.feedback_loop.suggest(history, current_actions)
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.end_headers()
+                    self.wfile.write(json.dumps(result).encode())
+                else:
+                    super().do_POST()
+
+        return Handler
+
+    def start(self):
+        if self._server:
+            return
+        handler = self._make_handler()
+        self._server = HTTPServer((self.host, self.port), handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        if self._server:
+            self._server.shutdown()
+            if self._thread:
+                self._thread.join()
+            self._server.server_close()
+            self._server = None
+            self._thread = None
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Start CAIEngine service")
+    parser.add_argument("--host", default="0.0.0.0", help="Bind host")
+    parser.add_argument("--port", type=int, default=8080, help="Bind port")
+    args = parser.parse_args(argv)
+
+    service = CAIService(host=args.host, port=args.port)
+    service.start()
+    try:
+        if service._thread:
+            service._thread.join()
+    except KeyboardInterrupt:
+        service.stop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create a CAIEngine service exposing HTTPContextProvider and goal suggestions
- add npcAiService.js to call the service when `CAI_ENGINE_ENDPOINT` is set
- document how to start the service

## Testing
- `./install_test_requirements.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68865652c990832a935302c6bfc0fc8b