### PR TITLE
Add RoboID distance and registry updates

### DIFF
--- a/src/caiengine/network/node_registry.py
+++ b/src/caiengine/network/node_registry.py
@@ -1,6 +1,8 @@
 """Redis-backed registry for tracking network members by RoboID."""
 
-from typing import Dict
+from typing import Dict, Union
+
+from .roboid import RoboId
 
 
 class NodeRegistry:
@@ -10,13 +12,23 @@ class NodeRegistry:
         self.redis = redis_client
         self.redis_key = redis_key
 
-    def join(self, robo_id: str, address: str) -> None:
-        """Register a node with its network address."""
-        self.redis.hset(self.redis_key, robo_id, address)
+    def join(self, robo_id: Union[str, RoboId], address: str) -> None:
+        """Register a node with its network address.
 
-    def leave(self, robo_id: str) -> None:
+        Parameters
+        ----------
+        robo_id:
+            Either a RoboId instance or RoboID string identifying the node.
+        address:
+            Network address of the node.
+        """
+        rid = str(robo_id) if isinstance(robo_id, RoboId) else robo_id
+        self.redis.hset(self.redis_key, rid, address)
+
+    def leave(self, robo_id: Union[str, RoboId]) -> None:
         """Remove a node from the registry."""
-        self.redis.hdel(self.redis_key, robo_id)
+        rid = str(robo_id) if isinstance(robo_id, RoboId) else robo_id
+        self.redis.hdel(self.redis_key, rid)
 
     def members(self) -> Dict[str, str]:
         """Return all registered nodes and their addresses."""

--- a/src/caiengine/network/roboid.py
+++ b/src/caiengine/network/roboid.py
@@ -60,3 +60,18 @@ class RoboId:
 
         similarity = score / 4.0
         return {"similarity": similarity, "differences": differences}
+
+    def distance(self, other: "RoboId") -> float:
+        """Return numeric distance between two RoboIDs.
+
+        This is defined as ``1 - similarity`` of the compared attributes.
+        """
+        return 1.0 - self.compare(other)["similarity"]
+
+    def is_visible_to(self, other: "RoboId") -> bool:
+        """Check if this RoboID should be considered visible to ``other``.
+
+        Currently nodes are visible to each other when they share the same
+        ``place`` value.
+        """
+        return self.place == other.place

--- a/tests/network/test_node_registry.py
+++ b/tests/network/test_node_registry.py
@@ -1,13 +1,27 @@
 import unittest
 import importlib.util
 from pathlib import Path
+import types
+import sys
 
 # Import NodeRegistry without pulling in heavy dependencies
-MODULE_PATH = Path(__file__).resolve().parents[2] / "src" / "caiengine" / "network" / "node_registry.py"
-spec = importlib.util.spec_from_file_location("node_registry", MODULE_PATH)
+MODULE_PATH = Path(__file__).resolve().parents[2]
+
+# Load RoboId first so the relative import in node_registry works
+ROBOID_PATH = MODULE_PATH / "src" / "caiengine" / "network" / "roboid.py"
+spec_roboid = importlib.util.spec_from_file_location("caiengine.network.roboid", ROBOID_PATH)
+roboid_module = importlib.util.module_from_spec(spec_roboid)
+spec_roboid.loader.exec_module(roboid_module)
+sys.modules['caiengine.network.roboid'] = roboid_module
+
+# Load NodeRegistry
+NR_PATH = MODULE_PATH / "src" / "caiengine" / "network" / "node_registry.py"
+spec = importlib.util.spec_from_file_location("caiengine.network.node_registry", NR_PATH)
 node_registry = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(node_registry)
+sys.modules['caiengine.network.node_registry'] = node_registry
 NodeRegistry = node_registry.NodeRegistry
+RoboId = roboid_module.RoboId
 
 
 class FakeRedis:
@@ -33,9 +47,13 @@ class TestNodeRegistry(unittest.TestCase):
     def test_join_and_members(self):
         self.registry.join("robot.control@A#1", "10.0.0.1")
         self.registry.join("robot.control@B#1", "10.0.0.2")
+        # Join using RoboId instance
+        rid = RoboId.parse("robot.virtual@wirtualny#42")
+        self.registry.join(rid, "10.0.0.9")
         members = self.registry.members()
         self.assertEqual(members["robot.control@A#1"], "10.0.0.1")
         self.assertEqual(members["robot.control@B#1"], "10.0.0.2")
+        self.assertEqual(members[str(rid)], "10.0.0.9")
 
     def test_leave(self):
         self.registry.join("robot.control@A#1", "10.0.0.1")

--- a/tests/network/test_roboid.py
+++ b/tests/network/test_roboid.py
@@ -27,6 +27,14 @@ class TestRoboId(unittest.TestCase):
         self.assertLess(result["similarity"], 1.0)
         self.assertIn("place", result["differences"])
 
+    def test_distance_and_visibility_virtual(self):
+        a = RoboId.parse("robot.transport@wirtualny#1")
+        b = RoboId.parse("robot.sensor@wirtualny#2")
+        self.assertTrue(a.is_visible_to(b))
+        dist = a.distance(b)
+        self.assertGreaterEqual(dist, 0.0)
+        self.assertLess(dist, 1.0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- expand `NodeRegistry` to accept `RoboId` instances
- add `distance` and `is_visible_to` helpers on `RoboId`
- extend network tests to cover RoboId distance/visibility and registry usage with objects

## Testing
- `pytest -q tests/network/test_node_registry.py tests/network/test_roboid.py`

------
https://chatgpt.com/codex/tasks/task_e_688a45df7370832a8b6c7453c3d0c7b2