### PR TITLE
Add prompt pipeline for text to context matrix

### DIFF
--- a/src/caiengine/__init__.py
+++ b/src/caiengine/__init__.py
@@ -13,7 +13,7 @@ try:  # pragma: no cover - optional dependency may be missing
     from caiengine.core.ai_inference import AIInferenceEngine
 except Exception:  # pragma: no cover - optional dependency may be missing
     AIInferenceEngine = None
-from caiengine.pipelines import ContextPipeline, FeedbackPipeline, QuestionPipeline, ConfigurablePipeline
+from caiengine.pipelines import ContextPipeline, FeedbackPipeline, QuestionPipeline, PromptPipeline, ConfigurablePipeline
 from caiengine.providers import MemoryContextProvider, KafkaContextProvider
 from caiengine.network import NetworkManager, SimpleNetworkMock, ContextBus, NodeRegistry
 from caiengine.interfaces import NetworkInterface
@@ -36,6 +36,7 @@ __all__ = [
     "ContextPipeline",
     "FeedbackPipeline",
     "QuestionPipeline",
+    "PromptPipeline",
     "ConfigurablePipeline",
     "Fuser",
     "ContextManager",

--- a/src/caiengine/parser/__init__.py
+++ b/src/caiengine/parser/__init__.py
@@ -3,5 +3,6 @@
 
 from .log_parser import LogParser
 from .robo_connector_normalizer import RoboConnectorNormalizer
+from .prompt_parser import PromptParser
 
-__all__ = ["LogParser", "RoboConnectorNormalizer"]
+__all__ = ["LogParser", "RoboConnectorNormalizer", "PromptParser"]

--- a/src/caiengine/parser/prompt_parser.py
+++ b/src/caiengine/parser/prompt_parser.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+class PromptParser:
+    """Very simple keyword-based parser that extracts context features from a text prompt.
+
+    The parser looks for known keywords related to time, location, role, label and mood and
+    maps them to the vocabulary expected by :class:`ContextEncoder`.
+    """
+
+    TIME_KEYWORDS = ["morning", "afternoon", "evening", "night", "before lunch"]
+    SPACE_KEYWORDS = {
+        "around the house": ["home", "house", "kitchen", "garden"],
+        "at office": ["office", "work", "desk"],
+        "warehouse": ["warehouse", "storage"],
+    }
+    ROLE_KEYWORDS = {
+        "admin": ["admin", "administrator", "root"],
+        "user": ["user", "client", "customer"],
+        "guest": ["guest", "visitor"],
+    }
+    LABEL_KEYWORDS = {
+        "invoice": ["invoice", "bill"],
+        "task": ["task", "todo"],
+        "report": ["report"],
+    }
+    MOOD_KEYWORDS = {
+        "happy": ["happy", "glad"],
+        "neutral": ["ok", "fine", "neutral"],
+        "stressed": ["stressed", "anxious", "worried"],
+    }
+
+    def _match_keyword(self, text: str, mapping: Dict[str, Any]) -> Optional[str]:
+        lower = text.lower()
+        for key, keywords in mapping.items():
+            if isinstance(keywords, list):
+                if any(kw in lower for kw in keywords):
+                    return key
+            else:  # when mapping is list
+                if key in lower:
+                    return key
+        return None
+
+    def _match_list(self, text: str, keywords: list[str]) -> Optional[str]:
+        lower = text.lower()
+        for kw in keywords:
+            if kw in lower:
+                return kw
+        return None
+
+    def transform(self, prompt: str) -> Dict[str, Any]:
+        """Transform ``prompt`` into a context dictionary."""
+        context: Dict[str, Any] = {
+            "time": self._match_list(prompt, self.TIME_KEYWORDS),
+            "space": self._match_keyword(prompt, self.SPACE_KEYWORDS),
+            "role": self._match_keyword(prompt, self.ROLE_KEYWORDS),
+            "label": self._match_keyword(prompt, self.LABEL_KEYWORDS),
+            "mood": self._match_keyword(prompt, self.MOOD_KEYWORDS),
+            "content": prompt,
+            "network": None,
+        }
+        return context

--- a/src/caiengine/pipelines/__init__.py
+++ b/src/caiengine/pipelines/__init__.py
@@ -2,6 +2,7 @@ from .context_pipeline import ContextPipeline
 from .vector_pipeline import VectorPipeline
 from .sensor_pipeline import SensorPipeline
 from .question_pipeline import QuestionPipeline
+from .prompt_pipeline import PromptPipeline
 from .configurable_pipeline import ConfigurablePipeline
 
 try:
@@ -9,6 +10,6 @@ try:
 except ModuleNotFoundError:
     FeedbackPipeline = None
 
-__all__ = ["ContextPipeline", "VectorPipeline", "SensorPipeline", "QuestionPipeline", "ConfigurablePipeline"]
+__all__ = ["ContextPipeline", "VectorPipeline", "SensorPipeline", "QuestionPipeline", "PromptPipeline", "ConfigurablePipeline"]
 if FeedbackPipeline is not None:
     __all__.insert(1, "FeedbackPipeline")

--- a/src/caiengine/pipelines/prompt_pipeline.py
+++ b/src/caiengine/pipelines/prompt_pipeline.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from caiengine.parser.prompt_parser import PromptParser
+from caiengine.core.vector_normalizer.context_encoder import ContextEncoder
+from caiengine.core.vector_normalizer.vector_comparer import VectorComparer
+from caiengine.core.fuser import Fuser
+from caiengine.interfaces.context_provider import ContextProvider
+from caiengine.interfaces.inference_engine import AIInferenceEngine
+from caiengine.objects.context_query import ContextQuery
+from caiengine.core.goal_feedback_loop import GoalDrivenFeedbackLoop
+
+
+class PromptPipeline:
+    """Pipeline that converts a text prompt into a context matrix and queries the provider.
+
+    The prompt is first parsed into a structured context using :class:`PromptParser`.
+    The resulting context dictionary is encoded as a vector (a "context matrix") which is
+    compared against stored context entries. The most similar items are fused and passed to
+    the supplied inference engine. Optionally a :class:`GoalDrivenFeedbackLoop` may adjust
+    the final result.
+    """
+
+    def __init__(
+        self,
+        context_provider: ContextProvider,
+        inference_engine: AIInferenceEngine,
+        feedback_loop: Optional[GoalDrivenFeedbackLoop] = None,
+        top_k: int = 3,
+    ) -> None:
+        self.provider = context_provider
+        self.engine = inference_engine
+        self.parser = PromptParser()
+        self.encoder = ContextEncoder()
+        self.comparer = VectorComparer()
+        self.fuser = Fuser()
+        self.feedback_loop = feedback_loop
+        self.top_k = top_k
+
+    def process(self, prompt: str, query: ContextQuery) -> Dict[str, any]:
+        """Process ``prompt`` against stored context and return the inference result."""
+        parsed = self.parser.transform(prompt)
+        vec = self.encoder.encode(parsed)
+        parsed["vector"] = vec
+
+        all_ctx = self.provider.get_context(query)
+        scored: List[Dict] = []
+        for item in all_ctx:
+            vec2 = item.get("vector")
+            if vec2 is None:
+                vec2 = self.encoder.encode(item.get("context", {}))
+            score = self.comparer.cosine_similarity(vec, vec2)
+            scored.append({"item": item, "score": score})
+        scored.sort(key=lambda x: x["score"], reverse=True)
+        top_items = [s["item"] for s in scored[: self.top_k]]
+        fused = self.fuser.fuse({("prompt", "", ""): top_items})
+        result = self.engine.predict({"prompt": prompt, "context": fused})
+        if self.feedback_loop:
+            suggestions = self.feedback_loop.suggest([], [result])
+            if suggestions:
+                result = suggestions[0]
+        return {"result": result, "parsed": parsed, "fused": fused}

--- a/tests/test_prompt_pipeline.py
+++ b/tests/test_prompt_pipeline.py
@@ -1,0 +1,39 @@
+import unittest
+from datetime import datetime, timedelta
+
+from caiengine.pipelines.prompt_pipeline import PromptPipeline
+from caiengine.providers.memory_context_provider import MemoryContextProvider
+from caiengine.interfaces.inference_engine import AIInferenceEngine
+from caiengine.objects.context_query import ContextQuery
+
+
+class Engine(AIInferenceEngine):
+    def predict(self, input_data):
+        return {"echo": input_data}
+
+
+class TestPromptPipeline(unittest.TestCase):
+    def test_prompt_pipeline(self):
+        provider = MemoryContextProvider()
+        now = datetime.utcnow()
+        provider.ingest_context(
+            {"time": "morning", "space": "around the house", "role": "user", "label": "task"},
+            timestamp=now,
+            metadata={"content": "first"},
+        )
+        query = ContextQuery(
+            roles=[],
+            time_range=(now - timedelta(seconds=1), now + timedelta(seconds=1)),
+            scope="",
+            data_type="",
+        )
+        pipeline = PromptPipeline(provider, Engine())
+        result = pipeline.process("user is happy at home in the morning", query)
+        self.assertIn("result", result)
+        self.assertIn("fused", result)
+        self.assertIn("parsed", result)
+        self.assertEqual(result["parsed"]["time"], "morning")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `PromptParser` for turning text prompts into context features
- create `PromptPipeline` that encodes prompts to vectors and queries context
- expose new pipeline and cover with unit test

## Testing
- `python -m pytest tests/test_prompt_pipeline.py -q`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f8f057d4c832a9e633f389fdfe05a