### PR TITLE
Add simple agent relationship network

### DIFF
--- a/src/caiengine/network/__init__.py
+++ b/src/caiengine/network/__init__.py
@@ -7,6 +7,7 @@ from .context_bus import ContextBus
 from .roboid import RoboId
 from .roboid_connection import RoboIdConnection
 from .node_registry import NodeRegistry
+from .agent_network import AgentNetwork
 
 __all__ = [
     "NetworkManager",
@@ -15,4 +16,5 @@ __all__ = [
     "RoboId",
     "RoboIdConnection",
     "NodeRegistry",
+    "AgentNetwork",
 ]

--- a/src/caiengine/network/agent_network.py
+++ b/src/caiengine/network/agent_network.py
@@ -1,0 +1,48 @@
+"""Simple in-memory graph to manage relationships between agents.
+
+This provides a lightweight adjacency mapping that tracks bidirectional
+relationships and optional weights between agents. It avoids introducing
+external dependencies while offering enough features for unit tests and
+simple orchestration logic.
+"""
+from __future__ import annotations
+
+from typing import Dict, Iterable, Optional
+
+
+class AgentNetwork:
+    """Maintain an undirected weighted graph of agents."""
+
+    def __init__(self) -> None:
+        # Mapping from agent -> {neighbor: weight}
+        self._edges: Dict[str, Dict[str, float]] = {}
+
+    def add_agent(self, agent_id: str) -> None:
+        """Ensure an agent exists in the graph."""
+        self._edges.setdefault(agent_id, {})
+
+    def connect(self, agent_a: str, agent_b: str, weight: float = 1.0) -> None:
+        """Create a bidirectional relationship between two agents."""
+        self.add_agent(agent_a)
+        self.add_agent(agent_b)
+        self._edges[agent_a][agent_b] = weight
+        self._edges[agent_b][agent_a] = weight
+
+    def disconnect(self, agent_a: str, agent_b: str) -> None:
+        """Remove the relationship between two agents if present."""
+        self._edges.get(agent_a, {}).pop(agent_b, None)
+        self._edges.get(agent_b, {}).pop(agent_a, None)
+
+    def relationship(self, agent_a: str, agent_b: str) -> Optional[float]:
+        """Return the weight of the relationship or ``None`` if absent."""
+        return self._edges.get(agent_a, {}).get(agent_b)
+
+    def neighbors(self, agent_id: str) -> Iterable[str]:
+        """Iterate over all directly connected agents."""
+        return self._edges.get(agent_id, {}).keys()
+
+    def remove_agent(self, agent_id: str) -> None:
+        """Remove an agent and all of its relationships."""
+        self._edges.pop(agent_id, None)
+        for edges in self._edges.values():
+            edges.pop(agent_id, None)

--- a/tests/network/test_agent_network.py
+++ b/tests/network/test_agent_network.py
@@ -1,0 +1,36 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+MODULE_PATH = Path(__file__).resolve().parents[2]
+AN_PATH = MODULE_PATH / "src" / "caiengine" / "network" / "agent_network.py"
+spec = importlib.util.spec_from_file_location(
+    "caiengine.network.agent_network", AN_PATH
+)
+agent_network = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(agent_network)
+sys.modules["caiengine.network.agent_network"] = agent_network
+AgentNetwork = agent_network.AgentNetwork
+
+
+def test_connect_and_relationship():
+    net = AgentNetwork()
+    net.connect("a", "b", weight=0.5)
+
+    assert net.relationship("a", "b") == 0.5
+    assert net.relationship("b", "a") == 0.5
+    assert set(net.neighbors("a")) == {"b"}
+    assert set(net.neighbors("b")) == {"a"}
+
+
+def test_disconnect_and_remove_agent():
+    net = AgentNetwork()
+    net.connect("a", "b")
+    net.connect("b", "c")
+
+    net.disconnect("a", "b")
+    assert net.relationship("a", "b") is None
+
+    net.remove_agent("b")
+    assert "b" not in set(net.neighbors("c"))
+    assert net.relationship("b", "c") is None


### PR DESCRIPTION
## Summary
- add `AgentNetwork` for tracking weighted relationships between agents
- expose `AgentNetwork` in network package
- test basic connect/disconnect logic

## Testing
- `pytest tests/network/test_agent_network.py -q`
- `pytest tests/network -q`

------
https://chatgpt.com/codex/tasks/task_e_688f99b8d5f4832a87553c4588fca6f8