### PR TITLE
docs: add goal-driven feedback use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ This modular architecture is designed to evolve alongside AI needs, helping to r
 - Model Management: Replace, save, and load AI inference models at runtime
 - Goal-Driven Feedback Loop: Nudge actions toward user-defined goals via strategies like ``SimpleGoalFeedbackStrategy`` or ``PersonalityGoalFeedbackStrategy`` for NPC traits
 
+## Goal-Driven Feedback Use Cases
+
+- **Learning & Skill Development** – Adaptive tutoring that delivers targeted feedback based on learner goals.
+- **Workplace Training & Coaching** – On-the-job coaching that evaluates progress on objectives and offers actionable guidance.
+- **Project Planning & Productivity** – Planning tools that track milestones and suggest adjustments when goals drift.
+- **Code Review & Software Quality** – Automated review systems that assess pull requests against project goals and supply structured feedback.
+- **Creative Work & Content Generation** – Writing assistants that help meet publishing goals through suggestions on tone and style.
+- **Research & Data Analysis** – Tools that keep researchers aligned with hypothesis-driven objectives via methodological feedback.
+
 ## Documentation
 
 Developer guides live in the `docs/` directory. Open

--- a/docs/theory/index.html
+++ b/docs/theory/index.html
@@ -30,6 +30,12 @@
       <li><strong>Multi-agent Decision Making:</strong> Coordinate tasks between AIs with awareness of each agent's role and environment.</li>
       <li><strong>Personalized Automation:</strong> Use context and trust layers to adapt workflows to individual users or machines.</li>
       <li><strong>Data Privacy Engines:</strong> Determine access rights based on context granularity and trust scores.</li>
+      <li><strong>Learning & Skill Development:</strong> Adaptive tutoring that gives targeted feedback based on learner goals.</li>
+      <li><strong>Workplace Training & Coaching:</strong> On-the-job coaching that evaluates performance on objectives and supplies guidance.</li>
+      <li><strong>Project Planning & Productivity:</strong> Collaborative tools that track progress toward milestones and suggest adjustments when goals drift.</li>
+      <li><strong>Code Review & Software Quality:</strong> Automated review systems that check pull requests against project goals and provide structured feedback.</li>
+      <li><strong>Creative Work & Content Generation:</strong> Writing assistants that help creators meet publishing goals with tone and style suggestions.</li>
+      <li><strong>Research & Data Analysis:</strong> Tools that keep researchers focused on hypotheses, offering methodological feedback.</li>
     </ul>
   </section>
 


### PR DESCRIPTION
## Summary
- document goal-driven feedback use cases in README
- expand theoretical use-case section with goal-driven scenarios

## Testing
- `./install_test_requirements.sh`
- `pytest` *(interrupted: KeyboardInterrupt after 24 passed tests)*

------
https://chatgpt.com/codex/tasks/task_e_68936b7d5204832aa722413024197106