### PR TITLE
Add mass testing for goal loop and feedback pipeline

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,3 +8,14 @@ This project ships developer guides and design notes as static HTML files.
 In the future these pages may move to a dedicated docs site (see
 [docs/dev/TECHNICAL_ROADMAP.md](dev/TECHNICAL_ROADMAP.md)).
 
+
+## Mass Testing
+
+Before going live, stress test the goal feedback loop and learning pipeline with synthetic data:
+
+```bash
+pytest tests/test_goal_feedback_loop.py::test_goal_feedback_loop_randomized_batch \
+       tests/test_feedback_pipeline.py::TestFeedbackPipeline::test_feedback_pipeline_randomized_batch
+```
+
+These tests generate many fake context maps to ensure the system behaves correctly under load. Extend them as needed for your own scenarios.

--- a/tests/test_feedback_pipeline.py
+++ b/tests/test_feedback_pipeline.py
@@ -39,5 +39,36 @@ class TestFeedbackPipeline(unittest.TestCase):
         self.assertIsInstance(updated, list)
 
 
+    def test_feedback_pipeline_randomized_batch(self):
+        provider = Provider()
+        log_parser = LogParser()
+        manager = LearningManager(input_size=4, parser=log_parser)
+        pipeline = FeedbackPipeline(provider, manager, learning_manager=manager)
+
+        data_batch = [
+            {
+                "id": i,
+                "roles": ["editor"],
+                "timestamp": provider.get_context()[0]["timestamp"],
+                "situations": [f"deal{i}"],
+                "content": f"Edit of deal{i}",
+                "context": {"deal": str(i)},
+                "confidence": 0.9,
+            }
+            for i in range(50)
+        ]
+        candidates = [
+            {"category": f"deal{i}", "context": {"deal": str(i)}, "base_weight": 1.0}
+            for i in range(50)
+        ]
+
+        results = pipeline.run(data_batch, candidates)
+        self.assertGreater(len(results), 0)
+        self.assertTrue(all("prediction" in r for r in results))
+
+        feedback = [(entry["content"], 1.0) for entry in data_batch[:5]]
+        updated = pipeline.run([], [], feedback=feedback)
+        self.assertIsInstance(updated, list)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_goal_feedback_loop.py
+++ b/tests/test_goal_feedback_loop.py
@@ -68,3 +68,13 @@ def test_goal_feedback_loop_directional_forward():
     actions = [{"time": 5}]
     suggested = loop.suggest(history, actions)
     assert suggested[0]["time"] == 7.5
+
+def test_goal_feedback_loop_randomized_batch():
+    strategy = SimpleGoalFeedbackStrategy()
+    loop = GoalDrivenFeedbackLoop(strategy, goal_state={"progress": 100})
+    history = [{"progress": i} for i in range(100)]
+    actions = [{"progress": i} for i in range(100)]
+    suggested = loop.suggest(history, actions)
+    assert len(suggested) == len(actions)
+    expected = history[-1]["progress"] + (100 - history[-1]["progress"]) * 0.5
+    assert all(act["progress"] == expected for act in suggested)


### PR DESCRIPTION
## Summary
- extend goal feedback loop tests with a randomized batch scenario
- add stress test for feedback pipeline using many fake context maps
- document how to run these mass tests before going live

## Testing
- `pytest tests/test_goal_feedback_loop.py::test_goal_feedback_loop_randomized_batch tests/test_feedback_pipeline.py::TestFeedbackPipeline::test_feedback_pipeline_randomized_batch -q`

------
https://chatgpt.com/codex/tasks/task_e_6897c8d5a748832a977da3e1f091e4d8