### PR TITLE
Add model metadata and storage utilities

### DIFF
--- a/src/caiengine/core/__init__.py
+++ b/src/caiengine/core/__init__.py
@@ -17,6 +17,7 @@ from .goal_strategies import (
     SimpleGoalFeedbackStrategy,
     PersonalityGoalFeedbackStrategy,
 )
+from .model_storage import save_model_with_metadata, load_model_with_metadata
 
 __all__ = [
     "CacheManager",
@@ -34,4 +35,6 @@ __all__ = [
     "GoalDrivenFeedbackLoop",
     "SimpleGoalFeedbackStrategy",
     "PersonalityGoalFeedbackStrategy",
+    "save_model_with_metadata",
+    "load_model_with_metadata",
 ]

--- a/src/caiengine/core/model_storage.py
+++ b/src/caiengine/core/model_storage.py
@@ -1,0 +1,50 @@
+"""Utilities for persisting models with accompanying metadata."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Tuple, Type
+
+import torch
+import torch.nn as nn
+
+from caiengine.objects.model_metadata import ModelMetadata
+
+MODEL_FILENAME = "model.pt"
+METADATA_FILENAME = "metadata.json"
+
+
+def save_model_with_metadata(
+    model: nn.Module, metadata: ModelMetadata, directory: str | Path
+) -> None:
+    """Save ``model`` and ``metadata`` into ``directory``.
+
+    The model's ``state_dict`` is saved using :func:`torch.save` and the metadata
+    is serialized to JSON.
+    """
+    dir_path = Path(directory)
+    dir_path.mkdir(parents=True, exist_ok=True)
+    torch.save(model.state_dict(), dir_path / MODEL_FILENAME)
+    with open(dir_path / METADATA_FILENAME, "w", encoding="utf-8") as fh:
+        json.dump(asdict(metadata), fh)
+
+
+def load_model_with_metadata(
+    model_class: Type[nn.Module], directory: str | Path
+) -> Tuple[nn.Module, ModelMetadata]:
+    """Load a model and its metadata from ``directory``.
+
+    ``model_class`` should be instantiable without arguments. The returned model
+    will have its parameters loaded from the stored state dictionary.
+    """
+    dir_path = Path(directory)
+    with open(dir_path / METADATA_FILENAME, "r", encoding="utf-8") as fh:
+        meta_dict = json.load(fh)
+    metadata = ModelMetadata(**meta_dict)
+
+    model = model_class()
+    state = torch.load(dir_path / MODEL_FILENAME, map_location="cpu")
+    model.load_state_dict(state)
+    return model, metadata

--- a/src/caiengine/objects/__init__.py
+++ b/src/caiengine/objects/__init__.py
@@ -4,5 +4,12 @@
 from .context_data import ContextData, SubscriptionHandle
 from .context_query import ContextQuery
 from .fused_context import FusedContext
+from .model_metadata import ModelMetadata
 
-__all__ = ["ContextData", "SubscriptionHandle", "ContextQuery", "FusedContext"]
+__all__ = [
+    "ContextData",
+    "SubscriptionHandle",
+    "ContextQuery",
+    "FusedContext",
+    "ModelMetadata",
+]

--- a/src/caiengine/objects/model_metadata.py
+++ b/src/caiengine/objects/model_metadata.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class ModelMetadata:
+    """Metadata describing a persisted model."""
+
+    model_name: str
+    version: str
+    supported_context_types: List[str]
+    training_hash: str

--- a/tests/test_model_storage_format.py
+++ b/tests/test_model_storage_format.py
@@ -1,0 +1,83 @@
+import importlib.util
+import json
+import pathlib
+import sys
+import types
+from dataclasses import asdict
+
+import torch
+import torch.nn as nn
+
+# Set up lightweight package structure to avoid importing heavy dependencies
+SRC_ROOT = pathlib.Path(__file__).resolve().parents[1] / "src" / "caiengine"
+
+caiengine_pkg = types.ModuleType("caiengine")
+caiengine_pkg.__path__ = []
+sys.modules.setdefault("caiengine", caiengine_pkg)
+
+objects_pkg = types.ModuleType("caiengine.objects")
+objects_pkg.__path__ = []
+sys.modules.setdefault("caiengine.objects", objects_pkg)
+
+spec_meta = importlib.util.spec_from_file_location(
+    "caiengine.objects.model_metadata", SRC_ROOT / "objects" / "model_metadata.py"
+)
+model_metadata_module = importlib.util.module_from_spec(spec_meta)
+spec_meta.loader.exec_module(model_metadata_module)
+sys.modules["caiengine.objects.model_metadata"] = model_metadata_module
+ModelMetadata = model_metadata_module.ModelMetadata
+
+core_pkg = types.ModuleType("caiengine.core")
+core_pkg.__path__ = []
+sys.modules.setdefault("caiengine.core", core_pkg)
+
+spec_storage = importlib.util.spec_from_file_location(
+    "caiengine.core.model_storage", SRC_ROOT / "core" / "model_storage.py"
+)
+model_storage_module = importlib.util.module_from_spec(spec_storage)
+spec_storage.loader.exec_module(model_storage_module)
+save_model_with_metadata = model_storage_module.save_model_with_metadata
+load_model_with_metadata = model_storage_module.load_model_with_metadata
+
+
+class SimpleModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(2, 1)
+
+    def forward(self, x):  # pragma: no cover - not used in tests
+        return self.linear(x)
+
+
+def create_sample_model_and_metadata():
+    model = SimpleModel()
+    with torch.no_grad():
+        model.linear.weight.fill_(1.0)
+        model.linear.bias.fill_(0.5)
+
+    metadata = ModelMetadata(
+        model_name="simple",
+        version="1.0",
+        supported_context_types=["text", "image"],
+        training_hash="abc123",
+    )
+    return model, metadata
+
+
+def test_round_trip_save_load(tmp_path):
+    model, metadata = create_sample_model_and_metadata()
+    save_model_with_metadata(model, metadata, tmp_path)
+
+    loaded_model, loaded_meta = load_model_with_metadata(SimpleModel, tmp_path)
+
+    assert asdict(loaded_meta) == asdict(metadata)
+    for p_orig, p_loaded in zip(model.parameters(), loaded_model.parameters()):
+        assert torch.equal(p_orig, p_loaded)
+
+
+def test_metadata_integrity(tmp_path):
+    model, metadata = create_sample_model_and_metadata()
+    save_model_with_metadata(model, metadata, tmp_path)
+    with open(tmp_path / "metadata.json", "r", encoding="utf-8") as fh:
+        on_disk = json.load(fh)
+    assert on_disk == asdict(metadata)


### PR DESCRIPTION
## Summary
- add `ModelMetadata` dataclass capturing model name, version, supported context types, and training hash
- implement `save_model_with_metadata` and `load_model_with_metadata` helpers for persisting models with metadata
- introduce unit tests covering round-trip model save/load and metadata integrity

## Testing
- `pytest tests/test_model_storage_format.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689f9565766c832a87a49290d637c567