### PR TITLE
Add model management CLI and integration tests

### DIFF
--- a/src/caiengine/__init__.py
+++ b/src/caiengine/__init__.py
@@ -1,59 +1,70 @@
+import os
+
 __version__ = "0.1.0"
 
-from caiengine.core import (
-    CacheManager,
-    ContextManager,
-    DistributedContextManager,
-    ContextHookManager,
-    ContextHook,
-    Fuser,
-    PolicyEvaluator,
-)
-try:  # pragma: no cover - optional dependency may be missing
-    from caiengine.core.ai_inference import AIInferenceEngine
-except Exception:  # pragma: no cover - optional dependency may be missing
-    AIInferenceEngine = None
-from caiengine.pipelines import ContextPipeline, FeedbackPipeline, QuestionPipeline, PromptPipeline, ConfigurablePipeline
-from caiengine.providers import MemoryContextProvider, KafkaContextProvider
-from caiengine.network import NetworkManager, SimpleNetworkMock, ContextBus, NodeRegistry
-from caiengine.interfaces import NetworkInterface
-from caiengine.core.goal_feedback_loop import GoalDrivenFeedbackLoop
-from caiengine.core.goal_strategies import (
-    SimpleGoalFeedbackStrategy,
-    PersonalityGoalFeedbackStrategy,
-)
-from caiengine.cai_bridge import CAIBridge
-try:
-    from . import cli as cli
-except Exception:  # pragma: no cover - fallback when not imported as package
-    import importlib
-    cli = importlib.import_module("cli")
+if not os.environ.get("CAIENGINE_LIGHT_IMPORT"):
+    from caiengine.core import (
+        CacheManager,
+        ContextManager,
+        DistributedContextManager,
+        ContextHookManager,
+        ContextHook,
+        Fuser,
+        PolicyEvaluator,
+    )
+    try:  # pragma: no cover - optional dependency may be missing
+        from caiengine.core.ai_inference import AIInferenceEngine
+    except Exception:  # pragma: no cover - optional dependency may be missing
+        AIInferenceEngine = None
+    from caiengine.pipelines import ContextPipeline, FeedbackPipeline, QuestionPipeline, PromptPipeline, ConfigurablePipeline
+    from caiengine.providers import MemoryContextProvider, KafkaContextProvider
+    from caiengine.network import NetworkManager, SimpleNetworkMock, ContextBus, NodeRegistry
+    from caiengine.interfaces import NetworkInterface
+    from caiengine.core.goal_feedback_loop import GoalDrivenFeedbackLoop
+    from caiengine.core.goal_strategies import (
+        SimpleGoalFeedbackStrategy,
+        PersonalityGoalFeedbackStrategy,
+    )
+    from caiengine.cai_bridge import CAIBridge
+    try:
+        from . import cli as cli
+    except Exception:  # pragma: no cover - fallback when not imported as package
+        import importlib
+        cli = importlib.import_module("cli")
 
-__all__ = [
-    "__version__",
-    "CacheManager",
-    "AIInferenceEngine",
-    "ContextPipeline",
-    "FeedbackPipeline",
-    "QuestionPipeline",
-    "PromptPipeline",
-    "ConfigurablePipeline",
-    "Fuser",
-    "ContextManager",
-    "DistributedContextManager",
-    "ContextHookManager",
-    "ContextHook",
-    "MemoryContextProvider",
-    "KafkaContextProvider",
-    "PolicyEvaluator",
-    "NetworkManager",
-    "SimpleNetworkMock",
-    "ContextBus",
-    "NodeRegistry",
-    "NetworkInterface",
-    "GoalDrivenFeedbackLoop",
-    "SimpleGoalFeedbackStrategy",
-    "PersonalityGoalFeedbackStrategy",
-    "CAIBridge",
-    "cli",
-]
+    __all__ = [
+        "__version__",
+        "CacheManager",
+        "AIInferenceEngine",
+        "ContextPipeline",
+        "FeedbackPipeline",
+        "QuestionPipeline",
+        "PromptPipeline",
+        "ConfigurablePipeline",
+        "Fuser",
+        "ContextManager",
+        "DistributedContextManager",
+        "ContextHookManager",
+        "ContextHook",
+        "MemoryContextProvider",
+        "KafkaContextProvider",
+        "PolicyEvaluator",
+        "NetworkManager",
+        "SimpleNetworkMock",
+        "ContextBus",
+        "NodeRegistry",
+        "NetworkInterface",
+        "GoalDrivenFeedbackLoop",
+        "SimpleGoalFeedbackStrategy",
+        "PersonalityGoalFeedbackStrategy",
+        "CAIBridge",
+        "cli",
+    ]
+else:  # pragma: no cover - lightweight import for CLI utilities
+    try:
+        from . import cli as cli
+    except Exception:  # pragma: no cover
+        import importlib
+        cli = importlib.import_module("cli")
+
+    __all__ = ["__version__", "cli"]

--- a/src/caiengine/cli.py
+++ b/src/caiengine/cli.py
@@ -4,6 +4,7 @@ import importlib
 import logging
 from datetime import datetime
 from caiengine.objects.context_query import ContextQuery
+from caiengine.core import model_manager
 
 DEFAULT_PROVIDER = "providers.memory_context_provider.MemoryContextProvider"
 
@@ -38,6 +39,17 @@ def cmd_query(args):
     result = provider.get_context(query)
     logger.info(json.dumps(result, default=str, indent=2))
 
+def cmd_model_load(args):
+    model_manager.transport_model(args.source, args.dest)
+    if args.version and not model_manager.check_version(args.dest, args.version):
+        raise RuntimeError("Model version mismatch")
+
+def cmd_model_migrate(args):
+    model_manager.upgrade_schema(args.path, args.target_version)
+
+def cmd_model_export(args):
+    model_manager.transport_model(args.path, args.dest)
+
 def main(argv=None):
     logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(prog="context")
@@ -58,12 +70,37 @@ def main(argv=None):
     query_p.add_argument("--scope", default="", help="Scope")
     query_p.add_argument("--data-type", default="", help="Data type")
 
+    model_p = sub.add_parser("model", help="Model operations")
+    model_sub = model_p.add_subparsers(dest="model_command")
+
+    load_p = model_sub.add_parser("load", help="Load model from source")
+    load_p.add_argument("--source", required=True, help="Source path or URL")
+    load_p.add_argument("--dest", required=True, help="Destination path")
+    load_p.add_argument("--version", default=None, help="Expected model version")
+
+    migrate_p = model_sub.add_parser("migrate", help="Migrate model schema")
+    migrate_p.add_argument("--path", required=True, help="Model file path")
+    migrate_p.add_argument("--target-version", required=True, help="Target schema version")
+
+    export_p = model_sub.add_parser("export", help="Export model to destination")
+    export_p.add_argument("--path", required=True, help="Model file path")
+    export_p.add_argument("--dest", required=True, help="Destination path")
+
     args = parser.parse_args(argv)
 
     if args.command == "add":
         cmd_add(args)
     elif args.command == "query":
         cmd_query(args)
+    elif args.command == "model":
+        if args.model_command == "load":
+            cmd_model_load(args)
+        elif args.model_command == "migrate":
+            cmd_model_migrate(args)
+        elif args.model_command == "export":
+            cmd_model_export(args)
+        else:
+            model_p.print_help()
     else:
         parser.print_help()
 

--- a/src/caiengine/core/__init__.py
+++ b/src/caiengine/core/__init__.py
@@ -1,37 +1,42 @@
 
 """Core utilities for the AI Context Framework."""
 
-from .cache_manager import CacheManager
-from .context_manager import ContextManager
-from .distributed_context_manager import DistributedContextManager
-from .context_hooks import ContextHookManager, ContextHook
-from .fuser import Fuser
-from .policy_evaluator import PolicyEvaluator
-from .categorizer import Categorizer
-from .context_filer import ContextFilter
-from .trust_module import TrustModule
-from .time_decay_scorer import TimeDecayScorer
-from .ann_index import ANNIndex
-from .goal_feedback_loop import GoalDrivenFeedbackLoop
-from .goal_strategies import (
-    SimpleGoalFeedbackStrategy,
-    PersonalityGoalFeedbackStrategy,
-)
+import os
 
-__all__ = [
-    "CacheManager",
-    "ContextManager",
-    "DistributedContextManager",
-    "ContextHookManager",
-    "ContextHook",
-    "Fuser",
-    "PolicyEvaluator",
-    "Categorizer",
-    "ContextFilter",
-    "TrustModule",
-    "TimeDecayScorer",
-    "ANNIndex",
-    "GoalDrivenFeedbackLoop",
-    "SimpleGoalFeedbackStrategy",
-    "PersonalityGoalFeedbackStrategy",
-]
+if not os.environ.get("CAIENGINE_LIGHT_IMPORT"):
+    from .cache_manager import CacheManager
+    from .context_manager import ContextManager
+    from .distributed_context_manager import DistributedContextManager
+    from .context_hooks import ContextHookManager, ContextHook
+    from .fuser import Fuser
+    from .policy_evaluator import PolicyEvaluator
+    from .categorizer import Categorizer
+    from .context_filer import ContextFilter
+    from .trust_module import TrustModule
+    from .time_decay_scorer import TimeDecayScorer
+    from .ann_index import ANNIndex
+    from .goal_feedback_loop import GoalDrivenFeedbackLoop
+    from .goal_strategies import (
+        SimpleGoalFeedbackStrategy,
+        PersonalityGoalFeedbackStrategy,
+    )
+
+    __all__ = [
+        "CacheManager",
+        "ContextManager",
+        "DistributedContextManager",
+        "ContextHookManager",
+        "ContextHook",
+        "Fuser",
+        "PolicyEvaluator",
+        "Categorizer",
+        "ContextFilter",
+        "TrustModule",
+        "TimeDecayScorer",
+        "ANNIndex",
+        "GoalDrivenFeedbackLoop",
+        "SimpleGoalFeedbackStrategy",
+        "PersonalityGoalFeedbackStrategy",
+    ]
+else:  # pragma: no cover - lightweight import
+    __all__ = []

--- a/src/caiengine/core/model_manager.py
+++ b/src/caiengine/core/model_manager.py
@@ -1,0 +1,47 @@
+import json
+import os
+import shutil
+from urllib.parse import urlparse
+from urllib.request import urlretrieve
+
+
+def _is_remote(path: str) -> bool:
+    parsed = urlparse(path)
+    return parsed.scheme in ("http", "https")
+
+
+def transport_model(src: str, dest: str) -> str:
+    """Copy or download a model file between storage backends.
+
+    If ``src`` is a remote URL (http/https) it will be downloaded to ``dest``.
+    Otherwise the file is copied locally.  The destination directory is
+    created if necessary.
+    """
+    os.makedirs(os.path.dirname(dest) or ".", exist_ok=True)
+    if _is_remote(src):
+        urlretrieve(src, dest)
+    else:
+        shutil.copy(src, dest)
+    return dest
+
+
+def check_version(path: str, expected: str) -> bool:
+    """Return True if the model file at ``path`` matches ``expected`` version."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data.get("version") == expected
+
+
+def upgrade_schema(path: str, target_version: str) -> None:
+    """Upgrade the model schema by setting its version fields.
+
+    The function reads the JSON model file at ``path`` and updates the
+    ``version`` and ``schema_version`` fields to ``target_version``.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    data["version"] = target_version
+    data["schema_version"] = target_version
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+

--- a/src/caiengine/interfaces/filter_strategy.py
+++ b/src/caiengine/interfaces/filter_strategy.py
@@ -1,5 +1,9 @@
 from typing import Any
-import numpy as np
+
+try:  # pragma: no cover - numpy is optional for simple filter strategy
+    import numpy as np  # noqa: F401
+except Exception:  # pragma: no cover - fallback when numpy missing
+    np = None
 
 
 class FilterStrategy:

--- a/tests/test_model_cli.py
+++ b/tests/test_model_cli.py
@@ -1,0 +1,72 @@
+import json
+import subprocess
+import sys
+import threading
+import http.server
+import socketserver
+import contextlib
+import os
+
+
+def run_cli(args, cwd=None):
+    src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, 'src'))
+    cli_path = os.path.join(src_path, 'caiengine', 'cli.py')
+    cmd = [sys.executable, cli_path] + args
+    env = os.environ.copy()
+    env['PYTHONPATH'] = src_path + os.pathsep + env.get('PYTHONPATH', '')
+    env['CAIENGINE_LIGHT_IMPORT'] = '1'
+    return subprocess.run(cmd, check=True, cwd=cwd, capture_output=True, env=env)
+
+
+@contextlib.contextmanager
+def run_server(directory):
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, directory=str(directory), **kwargs)
+
+    with socketserver.TCPServer(('127.0.0.1', 0), Handler) as httpd:
+        port = httpd.server_address[1]
+        thread = threading.Thread(target=httpd.serve_forever)
+        thread.daemon = True
+        thread.start()
+        try:
+            yield port
+        finally:
+            httpd.shutdown()
+            thread.join()
+
+
+def test_model_cli_local_workflow(tmp_path):
+    src = tmp_path / 'model_src.json'
+    with open(src, 'w', encoding='utf-8') as f:
+        json.dump({'version': '1.0', 'data': []}, f)
+
+    loaded = tmp_path / 'loaded.json'
+    run_cli(['model', 'load', '--source', str(src), '--dest', str(loaded), '--version', '1.0'])
+    assert loaded.exists()
+
+    run_cli(['model', 'migrate', '--path', str(loaded), '--target-version', '2.0'])
+    with open(loaded, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    assert data['version'] == '2.0'
+
+    exported = tmp_path / 'exported.json'
+    run_cli(['model', 'export', '--path', str(loaded), '--dest', str(exported)])
+    with open(exported, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    assert data['version'] == '2.0'
+
+
+def test_model_cli_remote_load(tmp_path):
+    remote_model = tmp_path / 'remote.json'
+    with open(remote_model, 'w', encoding='utf-8') as f:
+        json.dump({'version': '1.0'}, f)
+
+    with run_server(tmp_path) as port:
+        dest = tmp_path / 'download.json'
+        url = f'http://127.0.0.1:{port}/remote.json'
+        run_cli(['model', 'load', '--source', url, '--dest', str(dest)])
+        assert dest.exists()
+        with open(dest, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        assert data['version'] == '1.0'


### PR DESCRIPTION
## Summary
- extend CLI with `model load`, `model migrate`, and `model export` commands
- add `model_manager` helpers for version checking, schema upgrades, and transport
- include lightweight imports and optional numpy dependency
- cover model workflows with integration tests

## Testing
- `pytest tests/test_model_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689f956821c4832a89eeea620f1ea2e3