### PR TITLE
Add file-based model registry with tests

### DIFF
--- a/src/caiengine/network/__init__.py
+++ b/src/caiengine/network/__init__.py
@@ -8,6 +8,7 @@ from .roboid import RoboId
 from .roboid_connection import RoboIdConnection
 from .node_registry import NodeRegistry
 from .agent_network import AgentNetwork
+from .model_registry import ModelRegistry
 
 __all__ = [
     "NetworkManager",
@@ -17,4 +18,5 @@ __all__ = [
     "RoboIdConnection",
     "NodeRegistry",
     "AgentNetwork",
+    "ModelRegistry",
 ]

--- a/src/caiengine/network/model_registry.py
+++ b/src/caiengine/network/model_registry.py
@@ -1,0 +1,25 @@
+from typing import Any, Dict, List, Optional
+
+
+class ModelRegistry:
+    """Simple registry for storing and retrieving models.
+
+    The registry itself is backend agnostic and relies on a provided backend
+    object to persist entries.  The backend is expected to implement three
+    methods: ``register``, ``list`` and ``fetch``.
+    """
+
+    def __init__(self, backend: Any):
+        self.backend = backend
+
+    def register(self, model_id: str, version: str, data: Dict[str, Any]) -> None:
+        """Register a model entry with the underlying backend."""
+        self.backend.register(model_id, version, data)
+
+    def list(self) -> List[Dict[str, Any]]:
+        """Return all registered models from the backend."""
+        return self.backend.list()
+
+    def fetch(self, model_id: str, version: str) -> Optional[Dict[str, Any]]:
+        """Retrieve a model by identifier and version."""
+        return self.backend.fetch(model_id, version)

--- a/src/caiengine/providers/__init__.py
+++ b/src/caiengine/providers/__init__.py
@@ -15,6 +15,7 @@ from .kafka_context_provider import KafkaContextProvider
 from .xml_context_provider import XMLContextProvider
 from .postgres_context_provider import PostgresContextProvider
 from .mysql_context_provider import MySQLContextProvider
+from .file_model_registry import FileModelRegistry
 
 __all__ = [
     "BaseContextProvider",
@@ -31,4 +32,5 @@ __all__ = [
     "XMLContextProvider",
     "PostgresContextProvider",
     "MySQLContextProvider",
+    "FileModelRegistry",
 ]

--- a/src/caiengine/providers/file_model_registry.py
+++ b/src/caiengine/providers/file_model_registry.py
@@ -1,0 +1,46 @@
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+
+class FileModelRegistry:
+    """File based backend for :class:`ModelRegistry`.
+
+    Each registered model is stored as a JSON file on disk using the naming
+    convention ``<model_id>-<version>.json``.
+    """
+
+    def __init__(self, folder_path: str):
+        self.folder_path = folder_path
+        os.makedirs(self.folder_path, exist_ok=True)
+
+    def _file_path(self, model_id: str, version: str) -> str:
+        safe_id = model_id.replace(os.sep, "_")
+        safe_version = version.replace(os.sep, "_")
+        filename = f"{safe_id}-{safe_version}.json"
+        return os.path.join(self.folder_path, filename)
+
+    def register(self, model_id: str, version: str, data: Dict[str, Any]) -> None:
+        """Persist model information to disk."""
+        path = self._file_path(model_id, version)
+        record = {"id": model_id, "version": version, "data": data}
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(record, f)
+
+    def list(self) -> List[Dict[str, Any]]:
+        """Return all models stored on disk."""
+        results: List[Dict[str, Any]] = []
+        for fname in os.listdir(self.folder_path):
+            if fname.endswith(".json"):
+                path = os.path.join(self.folder_path, fname)
+                with open(path, "r", encoding="utf-8") as f:
+                    results.append(json.load(f))
+        return results
+
+    def fetch(self, model_id: str, version: str) -> Optional[Dict[str, Any]]:
+        """Retrieve a specific model entry."""
+        path = self._file_path(model_id, version)
+        if not os.path.exists(path):
+            return None
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,44 @@
+import importlib.util
+import pathlib
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+# Dynamically load modules to avoid importing heavy package dependencies
+model_registry_spec = importlib.util.spec_from_file_location(
+    "model_registry", ROOT / "src" / "caiengine" / "network" / "model_registry.py"
+)
+model_registry_module = importlib.util.module_from_spec(model_registry_spec)
+model_registry_spec.loader.exec_module(model_registry_module)
+ModelRegistry = model_registry_module.ModelRegistry
+
+file_registry_spec = importlib.util.spec_from_file_location(
+    "file_model_registry", ROOT / "src" / "caiengine" / "providers" / "file_model_registry.py"
+)
+file_registry_module = importlib.util.module_from_spec(file_registry_spec)
+file_registry_spec.loader.exec_module(file_registry_module)
+FileModelRegistry = file_registry_module.FileModelRegistry
+
+
+class TestModelRegistry(unittest.TestCase):
+    def test_register_and_fetch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            backend = FileModelRegistry(tmp)
+            registry = ModelRegistry(backend)
+            registry.register("test-model", "1", {"value": 1})
+            registry.register("test-model", "2", {"value": 2})
+
+            models = registry.list()
+            self.assertEqual(len(models), 2)
+
+            fetched = registry.fetch("test-model", "2")
+            self.assertIsNotNone(fetched)
+            self.assertEqual(fetched["data"], {"value": 2})
+
+            fetched_old = registry.fetch("test-model", "1")
+            self.assertEqual(fetched_old["data"], {"value": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Introduce `ModelRegistry` abstraction for registering, listing and fetching models
- Implement `FileModelRegistry` backend storing entries as JSON files
- Add tests validating registration and retrieval of models by id and version

## Testing
- `pytest tests/test_model_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f956a4558832aa91886f2ef6ec9c9