### PR TITLE
Document ONNX-based model bundle plan

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -48,6 +48,6 @@ Goal-driven feedback loop for adjusting actions toward target context states *(s
 
 # 🧠 Phase 6: Model Management & Storage
 Target: v0.6+
-- Establish a standardized model storage format with context-based metadata
+- Standardize model bundles around ONNX plus a context-aware manifest (see [docs/dev/model_storage_plan.md](docs/dev/model_storage_plan.md))
 - Provide tools for loading, migrating, and transporting models between environments
 - Enable a registry for discovering and retrieving context-aware models

--- a/docs/dev/model_storage_plan.md
+++ b/docs/dev/model_storage_plan.md
@@ -1,0 +1,36 @@
+# Model Storage & Registry Plan
+
+This document outlines the approach for Phase 6 of the project, delivering
+portable and context‑aware model bundles.
+
+## 1. Standard Representation
+
+- **ONNX as the core model format** for interoperability across runtimes.
+- A companion `manifest.yaml` or `manifest.toml` captures metadata such as
+  model name, version, training context, required preprocessing and
+  postprocessing steps, dependencies, and license details.
+
+## 2. Packaging
+
+- Package `model.onnx` and the manifest in a single archive (ZIP or OCI
+  artifact).
+- Optionally use content‑addressed or hashed file names to support
+  reproducibility.
+
+## 3. Tooling
+
+- Provide utilities to load, validate, and migrate bundles across
+  environments.
+- Include simple CLI helpers for exporting, importing, and verifying model
+  compatibility with the manifest.
+
+## 4. Registry Integration
+
+- Adopt a predictable bundle layout so a future registry can index manifest
+  fields for discovery.
+- Support context‑aware search and retrieval based on metadata such as
+  task, framework version, and required hardware.
+
+This plan establishes a portable "ONNX + manifest" standard, enabling
+consistent model management, transport, and discovery across the project.
+


### PR DESCRIPTION
## Summary
- Document ONNX + manifest approach for context-aware model bundles
- Link roadmap Phase 6 to new model storage plan

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a359316008832ab409d8d0ecd27d78