### PR TITLE
feat: add ONNX model bundles

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ dependencies = [
     "numpy>=2.2.6",
     "torch==2.3.1+cpu",
     "sympy>=1.14.0",
+    "PyYAML>=6.0.2",
+    "onnx>=1.17.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ setuptools==80.8.0
 sympy==1.14.0
 torch==2.3.1+cpu
 annoy==1.17.3
+pyyaml==6.0.2
+onnx==1.17.0

--- a/src/caiengine/__init__.py
+++ b/src/caiengine/__init__.py
@@ -11,6 +11,8 @@ if not os.environ.get("CAIENGINE_LIGHT_IMPORT"):
         ContextHook,
         Fuser,
         PolicyEvaluator,
+        export_onnx_bundle,
+        load_model_manifest,
         model_manager,
     )
     try:  # pragma: no cover - optional dependency may be missing
@@ -50,6 +52,8 @@ if not os.environ.get("CAIENGINE_LIGHT_IMPORT"):
         "MemoryContextProvider",
         "KafkaContextProvider",
         "PolicyEvaluator",
+        "export_onnx_bundle",
+        "load_model_manifest",
         "model_manager",
         "NetworkManager",
         "SimpleNetworkMock",

--- a/src/caiengine/core/__init__.py
+++ b/src/caiengine/core/__init__.py
@@ -23,6 +23,7 @@ if not os.environ.get("CAIENGINE_LIGHT_IMPORT"):
         PersonalityGoalFeedbackStrategy,
     )
     from .model_storage import save_model_with_metadata, load_model_with_metadata
+    from .model_bundle import export_onnx_bundle, load_model_manifest
 
     __all__ = [
         "CacheManager",
@@ -42,6 +43,8 @@ if not os.environ.get("CAIENGINE_LIGHT_IMPORT"):
         "PersonalityGoalFeedbackStrategy",
         "save_model_with_metadata",
         "load_model_with_metadata",
+        "export_onnx_bundle",
+        "load_model_manifest",
         "model_manager",
     ]
 else:  # pragma: no cover - lightweight import

--- a/src/caiengine/core/model_bundle.py
+++ b/src/caiengine/core/model_bundle.py
@@ -1,0 +1,42 @@
+"""Utilities for exporting models to portable ONNX bundles."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn as nn
+import yaml
+
+from caiengine.objects.model_manifest import ModelManifest
+
+MODEL_ONNX_FILENAME = "model.onnx"
+MANIFEST_FILENAME = "manifest.yaml"
+
+
+def export_onnx_bundle(
+    model: nn.Module,
+    example_input: Any,
+    manifest: ModelManifest,
+    directory: str | Path,
+) -> None:
+    """Export ``model`` and its ``manifest`` into ``directory``.
+
+    The model is exported to ONNX format using the provided ``example_input`` to
+    trace the model graph. ``manifest`` is serialized to YAML.
+    """
+    dir_path = Path(directory)
+    dir_path.mkdir(parents=True, exist_ok=True)
+    torch.onnx.export(model, example_input, dir_path / MODEL_ONNX_FILENAME)
+    with open(dir_path / MANIFEST_FILENAME, "w", encoding="utf-8") as fh:
+        yaml.safe_dump(asdict(manifest), fh)
+
+
+def load_model_manifest(directory: str | Path) -> ModelManifest:
+    """Load a :class:`ModelManifest` from ``directory``."""
+    dir_path = Path(directory)
+    with open(dir_path / MANIFEST_FILENAME, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    return ModelManifest(**data)

--- a/src/caiengine/objects/__init__.py
+++ b/src/caiengine/objects/__init__.py
@@ -5,6 +5,7 @@ from .context_data import ContextData, SubscriptionHandle
 from .context_query import ContextQuery
 from .fused_context import FusedContext
 from .model_metadata import ModelMetadata
+from .model_manifest import ModelManifest
 
 __all__ = [
     "ContextData",
@@ -12,4 +13,5 @@ __all__ = [
     "ContextQuery",
     "FusedContext",
     "ModelMetadata",
+    "ModelManifest",
 ]

--- a/src/caiengine/objects/model_manifest.py
+++ b/src/caiengine/objects/model_manifest.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class ModelManifest:
+    """Manifest describing a portable model bundle."""
+
+    model_name: str
+    version: str
+    training_context: Optional[str] = None
+    preprocessing: List[str] = field(default_factory=list)
+    postprocessing: List[str] = field(default_factory=list)
+    dependencies: Dict[str, str] = field(default_factory=dict)
+    license: Optional[str] = None

--- a/tests/test_model_bundle.py
+++ b/tests/test_model_bundle.py
@@ -1,0 +1,61 @@
+import importlib.util
+import pathlib
+import sys
+import types
+
+import torch
+import torch.nn as nn
+
+
+SRC_ROOT = pathlib.Path(__file__).resolve().parents[1] / "src" / "caiengine"
+
+# Create lightweight package structure
+caiengine_pkg = types.ModuleType("caiengine")
+caiengine_pkg.__path__ = []
+sys.modules.setdefault("caiengine", caiengine_pkg)
+
+objects_pkg = types.ModuleType("caiengine.objects")
+objects_pkg.__path__ = []
+sys.modules.setdefault("caiengine.objects", objects_pkg)
+
+spec_manifest = importlib.util.spec_from_file_location(
+    "caiengine.objects.model_manifest", SRC_ROOT / "objects" / "model_manifest.py"
+)
+manifest_module = importlib.util.module_from_spec(spec_manifest)
+spec_manifest.loader.exec_module(manifest_module)
+sys.modules["caiengine.objects.model_manifest"] = manifest_module
+ModelManifest = manifest_module.ModelManifest
+
+core_pkg = types.ModuleType("caiengine.core")
+core_pkg.__path__ = []
+sys.modules.setdefault("caiengine.core", core_pkg)
+
+spec_bundle = importlib.util.spec_from_file_location(
+    "caiengine.core.model_bundle", SRC_ROOT / "core" / "model_bundle.py"
+)
+bundle_module = importlib.util.module_from_spec(spec_bundle)
+spec_bundle.loader.exec_module(bundle_module)
+export_onnx_bundle = bundle_module.export_onnx_bundle
+load_model_manifest = bundle_module.load_model_manifest
+
+
+class SimpleModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(2, 1)
+
+    def forward(self, x):  # pragma: no cover - not used
+        return self.linear(x)
+
+
+def test_export_and_load_manifest(tmp_path):
+    model = SimpleModel()
+    manifest = ModelManifest(model_name="simple", version="1.0")
+    dummy_input = torch.randn(1, 2)
+
+    export_onnx_bundle(model, dummy_input, manifest, tmp_path)
+
+    assert (tmp_path / "model.onnx").exists()
+    loaded = load_model_manifest(tmp_path)
+    assert loaded.model_name == manifest.model_name
+    assert loaded.version == manifest.version


### PR DESCRIPTION
## Summary
- add dataclass for model bundle manifest
- export models with ONNX and YAML manifest
- expose new bundle helpers and add dependency on PyYAML and ONNX

## Testing
- `pytest tests/test_model_bundle.py`
- `pytest` *(fails: KeyboardInterrupt during tests/network/test_roboid_connection.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a439c61148832aab27579ab79418e0