### PR TITLE
Add intent classification pipeline

### DIFF
--- a/src/caiengine/parser/__init__.py
+++ b/src/caiengine/parser/__init__.py
@@ -4,5 +4,11 @@
 from .log_parser import LogParser
 from .robo_connector_normalizer import RoboConnectorNormalizer
 from .prompt_parser import PromptParser
+from .intent_classifier import IntentClassifier
 
-__all__ = ["LogParser", "RoboConnectorNormalizer", "PromptParser"]
+__all__ = [
+    "LogParser",
+    "RoboConnectorNormalizer",
+    "PromptParser",
+    "IntentClassifier",
+]

--- a/src/caiengine/parser/intent_classifier.py
+++ b/src/caiengine/parser/intent_classifier.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+
+class IntentClassifier:
+    """Naive rule-based intent classifier with funnel stage mapping.
+
+    The classifier splits a message into segments and assigns each
+    segment an intent and marketing funnel stage.
+    """
+
+    QUESTION_KEYWORDS = ["what", "how", "why", "when", "where", "who"]
+    PURCHASE_KEYWORDS = ["buy", "purchase", "order", "price", "cost", "subscribe", "sign up"]
+    SUPPORT_KEYWORDS = ["issue", "problem", "help", "support", "refund", "return"]
+    OBJECTION_KEYWORDS = ["don't", "not", "can't", "won't", "expensive", "concern"]
+
+    def segment(self, message: str) -> List[str]:
+        """Split ``message`` into sentence-like segments."""
+        parts = re.split(r"[.!?]", message)
+        return [p.strip() for p in parts if p.strip()]
+
+    def classify_segment(self, segment: str) -> Dict[str, str]:
+        """Classify a single ``segment`` and tag with funnel stage."""
+        lower = segment.lower()
+        if any(k in lower for k in self.SUPPORT_KEYWORDS):
+            intent = "support"
+            stage = "retention"
+        elif any(k in lower for k in self.QUESTION_KEYWORDS) or segment.strip().endswith("?"):
+            intent = "question"
+            stage = "awareness"
+        elif any(k in lower for k in self.PURCHASE_KEYWORDS):
+            intent = "purchase"
+            stage = "conversion"
+        elif any(k in lower for k in self.OBJECTION_KEYWORDS):
+            intent = "objection"
+            stage = "consideration"
+        else:
+            intent = "statement"
+            stage = "awareness"
+        return {"segment": segment, "intent": intent, "funnel_stage": stage}
+
+    def parse(self, message: str) -> List[Dict[str, str]]:
+        """Parse ``message`` into classified segments."""
+        segments = self.segment(message)
+        return [self.classify_segment(seg) for seg in segments]

--- a/src/caiengine/pipelines/__init__.py
+++ b/src/caiengine/pipelines/__init__.py
@@ -3,6 +3,7 @@ from .vector_pipeline import VectorPipeline
 from .sensor_pipeline import SensorPipeline
 from .question_pipeline import QuestionPipeline
 from .prompt_pipeline import PromptPipeline
+from .intent_pipeline import IntentPipeline
 from .configurable_pipeline import ConfigurablePipeline
 
 try:
@@ -10,6 +11,14 @@ try:
 except ModuleNotFoundError:
     FeedbackPipeline = None
 
-__all__ = ["ContextPipeline", "VectorPipeline", "SensorPipeline", "QuestionPipeline", "PromptPipeline", "ConfigurablePipeline"]
+__all__ = [
+    "ContextPipeline",
+    "VectorPipeline",
+    "SensorPipeline",
+    "QuestionPipeline",
+    "PromptPipeline",
+    "IntentPipeline",
+    "ConfigurablePipeline",
+]
 if FeedbackPipeline is not None:
     __all__.insert(1, "FeedbackPipeline")

--- a/src/caiengine/pipelines/intent_pipeline.py
+++ b/src/caiengine/pipelines/intent_pipeline.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import List, Dict, Optional
+
+from caiengine.parser.intent_classifier import IntentClassifier
+
+
+class IntentPipeline:
+    """Pipeline wrapper around :class:`IntentClassifier`.
+
+    This pipeline can be optionally inserted into a workflow to
+    extract intents and funnel stages from a free-form message.
+    """
+
+    def __init__(self, classifier: Optional[IntentClassifier] = None) -> None:
+        self.classifier = classifier or IntentClassifier()
+
+    def process(self, message: str) -> List[Dict[str, str]]:
+        """Return intent classifications for ``message``."""
+        return self.classifier.parse(message)

--- a/tests/parser/test_intent_classifier.py
+++ b/tests/parser/test_intent_classifier.py
@@ -1,0 +1,13 @@
+from caiengine.parser.intent_classifier import IntentClassifier
+
+
+def test_intent_classifier_segments_and_classifies():
+    clf = IntentClassifier()
+    message = "What is the price? I want to buy now. I have a problem with my order."
+    result = clf.parse(message)
+    assert result[0]["intent"] == "question"
+    assert result[0]["funnel_stage"] == "awareness"
+    assert result[1]["intent"] == "purchase"
+    assert result[1]["funnel_stage"] == "conversion"
+    assert result[2]["intent"] == "support"
+    assert result[2]["funnel_stage"] == "retention"

--- a/tests/test_intent_pipeline.py
+++ b/tests/test_intent_pipeline.py
@@ -1,0 +1,8 @@
+from caiengine.pipelines.intent_pipeline import IntentPipeline
+
+
+def test_intent_pipeline_processes_message():
+    pipeline = IntentPipeline()
+    result = pipeline.process("Can I return this? I want to buy another.")
+    assert result[0]["funnel_stage"] == "retention"
+    assert result[1]["funnel_stage"] == "conversion"


### PR DESCRIPTION
## Summary
- implement rule-based intent classifier mapping message segments to marketing funnel stages
- expose optional IntentPipeline wrapper for classification workflow
- cover intent segmentation and pipeline with unit tests

## Testing
- `CAIENGINE_LIGHT_IMPORT=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0307a4390832aa7af540656412bd5