### PR TITLE
Add parser utility for context matrix generation

### DIFF
--- a/src/caiengine/parser/prompt_parser.py
+++ b/src/caiengine/parser/prompt_parser.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
+
+from caiengine.core.vector_normalizer.context_encoder import ContextEncoder
 
 
 class PromptParser:
@@ -62,3 +64,20 @@ class PromptParser:
             "network": None,
         }
         return context
+
+    def parse_to_matrix(self, prompt: str) -> Tuple[Dict[str, Any], list]:
+        """Return context categories and their encoded matrix for ``prompt``.
+
+        The method first parses the natural language ``prompt`` into a context
+        dictionary using :meth:`transform`. The resulting dictionary is then
+        encoded into a numeric vector (context matrix) by
+        :class:`ContextEncoder`.
+
+        :param prompt: Natural language text describing a situation.
+        :return: Tuple of ``(context_dict, context_matrix)``.
+        """
+
+        context = self.transform(prompt)
+        encoder = ContextEncoder()
+        matrix = encoder.encode(context)
+        return context, matrix

--- a/tests/test_prompt_parser_matrix.py
+++ b/tests/test_prompt_parser_matrix.py
@@ -1,0 +1,12 @@
+from caiengine.parser.prompt_parser import PromptParser
+
+
+def test_parse_to_matrix():
+    parser = PromptParser()
+    ctx, matrix = parser.parse_to_matrix("user is happy at home in the morning")
+    assert ctx["time"] == "morning"
+    assert ctx["space"] == "around the house"
+    assert ctx["role"] == "user"
+    assert ctx["mood"] == "happy"
+    assert len(matrix) == 9
+


### PR DESCRIPTION
## Summary
- add `parse_to_matrix` method to `PromptParser` to return context categories and encoded vector
- cover parser with test exercising matrix output

## Testing
- `CAIENGINE_LIGHT_IMPORT=1 pytest -q tests/test_prompt_parser_matrix.py tests/test_prompt_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68c036bd7c30832a916156bd1b10ddd2