### PR TITLE
Add Redis and Kafka pub-sub communication channels

### DIFF
--- a/src/caiengine/__init__.py
+++ b/src/caiengine/__init__.py
@@ -21,7 +21,15 @@ if not os.environ.get("CAIENGINE_LIGHT_IMPORT"):
         AIInferenceEngine = None
     from caiengine.pipelines import ContextPipeline, FeedbackPipeline, QuestionPipeline, PromptPipeline, ConfigurablePipeline
     from caiengine.providers import MemoryContextProvider, KafkaContextProvider, FileModelRegistry
-    from caiengine.network import NetworkManager, SimpleNetworkMock, ContextBus, NodeRegistry, ModelRegistry
+    from caiengine.network import (
+        NetworkManager,
+        SimpleNetworkMock,
+        ContextBus,
+        NodeRegistry,
+        ModelRegistry,
+        RedisPubSubChannel,
+        KafkaPubSubChannel,
+    )
     from caiengine.interfaces import NetworkInterface
     from caiengine.core.goal_feedback_loop import GoalDrivenFeedbackLoop
     from caiengine.core.goal_strategies import (
@@ -60,6 +68,8 @@ if not os.environ.get("CAIENGINE_LIGHT_IMPORT"):
         "ContextBus",
         "NodeRegistry",
         "ModelRegistry",
+        "RedisPubSubChannel",
+        "KafkaPubSubChannel",
         "NetworkInterface",
         "GoalDrivenFeedbackLoop",
         "SimpleGoalFeedbackStrategy",

--- a/src/caiengine/interfaces/__init__.py
+++ b/src/caiengine/interfaces/__init__.py
@@ -9,6 +9,7 @@ from .inference_engine import AIInferenceEngine
 from .learning_interface import LearningInterface
 from .context_scorer import ContextScorer
 from .goal_feedback_strategy import GoalFeedbackStrategy
+from .communication_channel import CommunicationChannel
 
 __all__ = [
     "ContextProvider",
@@ -19,4 +20,5 @@ __all__ = [
     "LearningInterface",
     "ContextScorer",
     "GoalFeedbackStrategy",
+    "CommunicationChannel",
 ]

--- a/src/caiengine/interfaces/communication_channel.py
+++ b/src/caiengine/interfaces/communication_channel.py
@@ -1,0 +1,24 @@
+"""Interface for pub/sub communication channels."""
+
+from abc import ABC, abstractmethod
+from typing import Callable, Dict, Any
+
+
+class CommunicationChannel(ABC):
+    """Abstract base class for pub/sub communication channels."""
+
+    @abstractmethod
+    def publish(self, topic: str, message: Dict[str, Any]) -> None:
+        """Publish a message to a topic."""
+
+    @abstractmethod
+    def subscribe(self, topic: str, callback: Callable[[Dict[str, Any]], None]) -> None:
+        """Subscribe to a topic and invoke ``callback`` for each message."""
+
+    @abstractmethod
+    def unsubscribe(self, topic: str) -> None:
+        """Unsubscribe from a topic."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Close the channel and release resources."""

--- a/src/caiengine/network/__init__.py
+++ b/src/caiengine/network/__init__.py
@@ -9,6 +9,8 @@ from .roboid_connection import RoboIdConnection
 from .node_registry import NodeRegistry
 from .agent_network import AgentNetwork
 from .model_registry import ModelRegistry
+from .redis_pubsub_channel import RedisPubSubChannel
+from .kafka_pubsub_channel import KafkaPubSubChannel
 
 __all__ = [
     "NetworkManager",
@@ -19,4 +21,6 @@ __all__ = [
     "NodeRegistry",
     "AgentNetwork",
     "ModelRegistry",
+    "RedisPubSubChannel",
+    "KafkaPubSubChannel",
 ]

--- a/src/caiengine/network/kafka_pubsub_channel.py
+++ b/src/caiengine/network/kafka_pubsub_channel.py
@@ -1,0 +1,58 @@
+"""Kafka implementation of :class:`CommunicationChannel`."""
+
+import json
+import threading
+from typing import Callable, Dict, Any
+
+from kafka import KafkaProducer, KafkaConsumer
+
+from caiengine.interfaces.communication_channel import CommunicationChannel
+
+
+class KafkaPubSubChannel(CommunicationChannel):
+    """Kafka backed pub/sub channel."""
+
+    def __init__(self, bootstrap_servers: str = "localhost:9092", group_id: str | None = None):
+        self._producer = KafkaProducer(
+            bootstrap_servers=bootstrap_servers,
+            value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+        )
+        self._bootstrap_servers = bootstrap_servers
+        self._group_id = group_id
+        self._consumers: Dict[str, KafkaConsumer] = {}
+        self._threads: Dict[str, threading.Thread] = {}
+
+    def publish(self, topic: str, message: Dict[str, Any]) -> None:
+        self._producer.send(topic, message)
+        self._producer.flush()
+
+    def subscribe(self, topic: str, callback: Callable[[Dict[str, Any]], None]) -> None:
+        consumer = KafkaConsumer(
+            topic,
+            bootstrap_servers=self._bootstrap_servers,
+            group_id=self._group_id,
+            value_deserializer=lambda m: json.loads(m.decode("utf-8")),
+            auto_offset_reset="earliest",
+            enable_auto_commit=True,
+        )
+        thread = threading.Thread(target=self._consume, args=(topic, callback, consumer), daemon=True)
+        thread.start()
+        self._consumers[topic] = consumer
+        self._threads[topic] = thread
+
+    def _consume(self, topic: str, callback: Callable[[Dict[str, Any]], None], consumer: KafkaConsumer) -> None:
+        for message in consumer:
+            callback(message.value)
+
+    def unsubscribe(self, topic: str) -> None:
+        consumer = self._consumers.pop(topic, None)
+        if consumer:
+            consumer.close()
+        thread = self._threads.pop(topic, None)
+        if thread and thread.is_alive():
+            thread.join(timeout=0)
+
+    def close(self) -> None:
+        for topic in list(self._consumers.keys()):
+            self.unsubscribe(topic)
+        self._producer.close()

--- a/src/caiengine/network/redis_pubsub_channel.py
+++ b/src/caiengine/network/redis_pubsub_channel.py
@@ -1,0 +1,55 @@
+"""Redis implementation of :class:`CommunicationChannel`."""
+
+import json
+from typing import Callable, Dict, Any
+
+from redis import Redis
+
+from caiengine.interfaces.communication_channel import CommunicationChannel
+
+
+class RedisPubSubChannel(CommunicationChannel):
+    """Simple Redis backed pub/sub channel."""
+
+    def __init__(self, host: str = "localhost", port: int = 6379, db: int = 0):
+        self._client = Redis(host=host, port=port, db=db)
+        self._pubsub = self._client.pubsub()
+        self._thread = None
+        self._callbacks: Dict[str, Callable[[Dict[str, Any]], None]] = {}
+
+    def publish(self, topic: str, message: Dict[str, Any]) -> None:
+        payload = json.dumps(message)
+        self._client.publish(topic, payload)
+
+    def subscribe(self, topic: str, callback: Callable[[Dict[str, Any]], None]) -> None:
+        self._callbacks[topic] = callback
+        self._pubsub.subscribe(**{topic: self._create_handler(topic)})
+        if self._thread is None:
+            # ``run_in_thread`` returns a ``PubSubWorkerThread``
+            self._thread = self._pubsub.run_in_thread(daemon=True)
+
+    def _create_handler(self, topic: str):
+        def handler(message):
+            if message.get("type") == "message":
+                data = message.get("data")
+                if isinstance(data, bytes):
+                    data = data.decode("utf-8")
+                try:
+                    payload = json.loads(data)
+                except Exception:
+                    payload = data
+                cb = self._callbacks.get(topic)
+                if cb:
+                    cb(payload)
+        return handler
+
+    def unsubscribe(self, topic: str) -> None:
+        self._pubsub.unsubscribe(topic)
+        self._callbacks.pop(topic, None)
+
+    def close(self) -> None:
+        if self._thread is not None:
+            self._thread.stop()
+            self._thread = None
+        self._pubsub.close()
+        self._client.close()

--- a/tests/network/test_pubsub_channels.py
+++ b/tests/network/test_pubsub_channels.py
@@ -1,0 +1,47 @@
+import json
+import os
+from unittest import mock
+
+os.environ.setdefault("CAIENGINE_LIGHT_IMPORT", "1")
+
+from caiengine.network.redis_pubsub_channel import RedisPubSubChannel
+from caiengine.network.kafka_pubsub_channel import KafkaPubSubChannel
+
+
+def test_redis_pubsub_channel_publish_subscribe():
+    mock_pubsub = mock.Mock()
+    mock_thread = mock.Mock()
+    mock_pubsub.run_in_thread.return_value = mock_thread
+    mock_redis = mock.Mock()
+    mock_redis.pubsub.return_value = mock_pubsub
+    with mock.patch("caiengine.network.redis_pubsub_channel.Redis", return_value=mock_redis):
+        channel = RedisPubSubChannel()
+        channel.publish("topic", {"foo": "bar"})
+        mock_redis.publish.assert_called_once_with("topic", json.dumps({"foo": "bar"}))
+
+        callback = mock.Mock()
+        channel.subscribe("topic", callback)
+        mock_pubsub.subscribe.assert_called_once()
+        mock_pubsub.run_in_thread.assert_called_once()
+
+
+def test_kafka_pubsub_channel_publish_subscribe():
+    mock_producer = mock.Mock()
+    mock_consumer = mock.Mock()
+    with (
+        mock.patch("caiengine.network.kafka_pubsub_channel.KafkaProducer", return_value=mock_producer),
+        mock.patch("caiengine.network.kafka_pubsub_channel.KafkaConsumer", return_value=mock_consumer) as consumer_cls,
+        mock.patch("threading.Thread") as thread_cls,
+    ):
+        dummy_thread = mock.Mock()
+        thread_cls.return_value = dummy_thread
+
+        channel = KafkaPubSubChannel()
+        channel.publish("topic", {"foo": "bar"})
+        mock_producer.send.assert_called_once_with("topic", {"foo": "bar"})
+        mock_producer.flush.assert_called_once()
+
+        callback = mock.Mock()
+        channel.subscribe("topic", callback)
+        consumer_cls.assert_called_once()
+        dummy_thread.start.assert_called_once()


### PR DESCRIPTION
## Summary
- add `CommunicationChannel` interface
- implement `RedisPubSubChannel` and `KafkaPubSubChannel`
- expose new channels via package exports and tests

## Testing
- `pytest tests/network/test_pubsub_channels.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c03939f5c0832ab0a9d0b37b4f782d