### PR TITLE
Scaffold goal feedback loop infrastructure

### DIFF
--- a/docs/dev/goal_feedback_loop.md
+++ b/docs/dev/goal_feedback_loop.md
@@ -5,11 +5,20 @@ Client applications often need to steer actions toward a target without pausing 
 ## Background Worker
 Run the loop inside a background worker, service worker, or scheduled task. The worker should periodically poll for new actions or subscribe to an event stream.
 
+Use the scaffold in ``GoalFeedbackWorker`` as a starting point.
+TODO: implement real polling logic and persistence integration.
+
 ## State Tracking
 Persist the current goal state and any progress metrics in storage accessible by the worker (memory, local database, etc.). Update this state whenever goals change so the loop can compare new actions against the latest target.
 
+``GoalStateTracker`` currently stores data in memory only.
+TODO: hook this into a durable database or cache.
+
 ## Event-Driven Updates
 When a new action appears, send it to the worker through a queue or message channel. The worker computes suggestions only when history or goal state changes, limiting needless work.
+
+``FeedbackEventBus`` offers a minimal publish/subscribe interface.
+TODO: replace with an async queue or external message broker.
 
 ## Suggestion Logic
 Instantiate `GoalDrivenFeedbackLoop` with a strategy such as `SimpleGoalFeedbackStrategy` or `PersonalityGoalFeedbackStrategy`. Call `suggest_actions` with the current history and new actions to receive nudges toward the goal state.

--- a/src/caiengine/__init__.py
+++ b/src/caiengine/__init__.py
@@ -28,6 +28,9 @@ if not os.environ.get("CAIENGINE_LIGHT_IMPORT"):
         SimpleGoalFeedbackStrategy,
         PersonalityGoalFeedbackStrategy,
     )
+    from caiengine.core.goal_feedback_worker import GoalFeedbackWorker
+    from caiengine.core.goal_state_tracker import GoalStateTracker
+    from caiengine.core.feedback_event_bus import FeedbackEventBus
     from caiengine.cai_bridge import CAIBridge
     try:
         from . import cli as cli
@@ -64,6 +67,9 @@ if not os.environ.get("CAIENGINE_LIGHT_IMPORT"):
         "GoalDrivenFeedbackLoop",
         "SimpleGoalFeedbackStrategy",
         "PersonalityGoalFeedbackStrategy",
+        "GoalFeedbackWorker",
+        "GoalStateTracker",
+        "FeedbackEventBus",
         "CAIBridge",
         "FileModelRegistry",
         "cli",

--- a/src/caiengine/core/__init__.py
+++ b/src/caiengine/core/__init__.py
@@ -22,6 +22,9 @@ if not os.environ.get("CAIENGINE_LIGHT_IMPORT"):
         SimpleGoalFeedbackStrategy,
         PersonalityGoalFeedbackStrategy,
     )
+    from .goal_feedback_worker import GoalFeedbackWorker
+    from .goal_state_tracker import GoalStateTracker
+    from .feedback_event_bus import FeedbackEventBus
     from .model_storage import save_model_with_metadata, load_model_with_metadata
     from .model_bundle import export_onnx_bundle, load_model_manifest
 
@@ -41,6 +44,9 @@ if not os.environ.get("CAIENGINE_LIGHT_IMPORT"):
         "GoalDrivenFeedbackLoop",
         "SimpleGoalFeedbackStrategy",
         "PersonalityGoalFeedbackStrategy",
+        "GoalFeedbackWorker",
+        "GoalStateTracker",
+        "FeedbackEventBus",
         "save_model_with_metadata",
         "load_model_with_metadata",
         "export_onnx_bundle",

--- a/src/caiengine/core/feedback_event_bus.py
+++ b/src/caiengine/core/feedback_event_bus.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List
+
+
+class FeedbackEventBus:
+    """Simple publish/subscribe bus for goal feedback events."""
+
+    def __init__(self) -> None:
+        self._subscribers: List[Callable[[Dict[str, Any]], None]] = []
+
+    def subscribe(self, handler: Callable[[Dict[str, Any]], None]) -> None:
+        """Register a callback for future events."""
+        self._subscribers.append(handler)
+
+    def publish(self, event: Dict[str, Any]) -> None:
+        """Send ``event`` to all subscribers."""
+        # TODO: Replace with async queue or external message broker
+        for handler in list(self._subscribers):
+            handler(event)

--- a/src/caiengine/core/goal_feedback_worker.py
+++ b/src/caiengine/core/goal_feedback_worker.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import threading
+import time
+from typing import Dict, List, Optional
+
+from .goal_feedback_loop import GoalDrivenFeedbackLoop
+from .goal_state_tracker import GoalStateTracker
+from .feedback_event_bus import FeedbackEventBus
+
+
+class GoalFeedbackWorker:
+    """Background worker that keeps the goal feedback loop running.
+
+    This scaffold wires the loop to an event bus and a simple state tracker.
+    """
+
+    def __init__(
+        self,
+        loop: GoalDrivenFeedbackLoop,
+        event_bus: FeedbackEventBus,
+        state_tracker: GoalStateTracker | None = None,
+        poll_interval: float = 5.0,
+    ) -> None:
+        self.loop = loop
+        self.event_bus = event_bus
+        self.state_tracker = state_tracker or GoalStateTracker()
+        self.poll_interval = poll_interval
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+        self.event_bus.subscribe(self._handle_event)
+
+    def start(self) -> None:
+        """Start the background thread."""
+        # TODO: Consider using asyncio or external worker system
+        if self._thread and self._thread.is_alive():
+            return
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Signal the worker to terminate."""
+        self._stop.set()
+        if self._thread:
+            self._thread.join()
+
+    def _handle_event(self, event: Dict) -> None:
+        """React to new actions or goal changes."""
+        # TODO: Feed actions to loop and persist results
+        pass
+
+    def _run(self) -> None:
+        """Main polling loop."""
+        history: List[Dict] = []
+        while not self._stop.is_set():
+            # TODO: Poll external sources for new actions
+            time.sleep(self.poll_interval)

--- a/src/caiengine/core/goal_state_tracker.py
+++ b/src/caiengine/core/goal_state_tracker.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class GoalStateTracker:
+    """Persist and retrieve goal feedback loop state.
+
+    This is a placeholder for more robust storage such as a database or
+    distributed cache.
+    """
+
+    def __init__(self) -> None:
+        # TODO: Allow injecting persistence backend (e.g., Redis, file, DB)
+        self._state: Dict[str, Any] = {}
+
+    def load(self) -> Dict[str, Any]:
+        """Return the last known goal state and progress metrics."""
+        # TODO: Replace in-memory store with persistent storage
+        return self._state
+
+    def save(self, state: Dict[str, Any]) -> None:
+        """Persist updated goal state."""
+        # TODO: Persist state to chosen backend
+        self._state = dict(state)


### PR DESCRIPTION
## Summary
- add `GoalFeedbackWorker` stub to run feedback loop in the background
- introduce in-memory `GoalStateTracker` and `FeedbackEventBus` placeholders
- document next steps for worker, state tracking, and event-driven updates

## Testing
- `CAIENGINE_LIGHT_IMPORT=1 pytest tests/test_goal_feedback_loop.py tests/test_personality_goal_strategy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c038722c84832aaffd047b7135555d