### PR TITLE
Add audit logging system for pipelines

### DIFF
--- a/src/caiengine/common/__init__.py
+++ b/src/caiengine/common/__init__.py
@@ -1,0 +1,3 @@
+from .audit_logger import AuditLogger
+
+__all__ = ["AuditLogger"]

--- a/src/caiengine/common/audit_logger.py
+++ b/src/caiengine/common/audit_logger.py
@@ -1,0 +1,28 @@
+import logging
+from typing import Any, Dict, List, Optional
+
+class AuditLogger:
+    """Simple audit logger that records pipeline steps.
+
+    Records are stored in-memory and also emitted via the standard
+    :mod:`logging` module so applications can configure handlers as needed.
+    """
+
+    def __init__(self, logger: Optional[logging.Logger] = None) -> None:
+        self.logger = logger or logging.getLogger("caiengine.audit")
+        self.records: List[Dict[str, Any]] = []
+
+    def log(self, pipeline: str, step: str, detail: Optional[Dict[str, Any]] = None) -> None:
+        """Register a pipeline ``step`` with optional ``detail`` data."""
+        entry: Dict[str, Any] = {"pipeline": pipeline, "step": step}
+        if detail:
+            entry["detail"] = detail
+        self.records.append(entry)
+        if detail:
+            self.logger.info("%s - %s - %s", pipeline, step, detail)
+        else:
+            self.logger.info("%s - %s", pipeline, step)
+
+    def get_records(self) -> List[Dict[str, Any]]:
+        """Return all collected audit records."""
+        return list(self.records)

--- a/src/caiengine/pipelines/configurable_pipeline.py
+++ b/src/caiengine/pipelines/configurable_pipeline.py
@@ -20,6 +20,7 @@ from caiengine.core.goal_feedback_loop import GoalDrivenFeedbackLoop
 from caiengine.core.goal_strategies.simple_goal_strategy import SimpleGoalFeedbackStrategy
 from caiengine.policies.simple_policy import SimplePolicyEvaluator
 from caiengine.parser.log_parser import LogParser
+from caiengine.common import AuditLogger
 
 
 _PROVIDER_MAP = {
@@ -40,9 +41,10 @@ class ConfigurablePipeline:
     trust_module: Optional[TrustModule] = None
     policy: Optional[SimplePolicyEvaluator] = None
     feedback_loop: Optional[GoalDrivenFeedbackLoop] = None
+    audit_logger: AuditLogger | None = None
 
     @classmethod
-    def from_dict(cls, cfg: Dict[str, Any]) -> "ConfigurablePipeline":
+    def from_dict(cls, cfg: Dict[str, Any], audit_logger: AuditLogger | None = None) -> "ConfigurablePipeline":
         prov_cfg = cfg.get("provider", {})
         prov_type = prov_cfg.get("type", "memory")
         prov_args = prov_cfg.get("args", {})
@@ -65,7 +67,7 @@ class ConfigurablePipeline:
         feedback_cfg = cfg.get("feedback") or {}
         feedback_loop = None
         if not feedback_cfg:
-            pipeline = ContextPipeline(provider)
+            pipeline = ContextPipeline(provider, audit_logger=audit_logger)
         elif feedback_cfg.get("type") == "complex_nn":
             from caiengine.core.learning.learning_manager import LearningManager
             manager = LearningManager(
@@ -77,11 +79,11 @@ class ConfigurablePipeline:
             engine = TokenUsageTracker(manager.inference_engine)
             manager.inference_engine = engine
             pipeline = FeedbackPipeline(
-                provider, engine, learning_manager=manager
+                provider, engine, learning_manager=manager, audit_logger=audit_logger
             )
         elif feedback_cfg.get("type") == "goal":
             engine = TokenUsageTracker(DummyAIInferenceEngine())
-            pipeline = FeedbackPipeline(provider, engine)
+            pipeline = FeedbackPipeline(provider, engine, audit_logger=audit_logger)
             strategy = SimpleGoalFeedbackStrategy(
                 feedback_cfg.get("one_direction_layers", [])
             )
@@ -99,6 +101,7 @@ class ConfigurablePipeline:
             trust_module=trust_module,
             policy=policy,
             feedback_loop=feedback_loop,
+            audit_logger=audit_logger,
         )
 
     def run(self, data_batch: List[Any]) -> List[Dict]:
@@ -108,7 +111,13 @@ class ConfigurablePipeline:
                 item = self.parser.transform(item)
             processed.append(item)
 
+        if self.audit_logger:
+            self.audit_logger.log("ConfigurablePipeline", "preprocessed", {"items": len(processed)})
+
         results = self.pipeline.run(processed, self.candidates or [])
+
+        if self.audit_logger:
+            self.audit_logger.log("ConfigurablePipeline", "pipeline_run", {"results": len(results) if isinstance(results, list) else len(results.keys())})
 
         if isinstance(results, dict):
             results = [dict(v, category=k) for k, v in results.items()]
@@ -127,17 +136,23 @@ class ConfigurablePipeline:
                         res["prediction"] = pred
                     filtered.append(res)
             results = filtered
+            if self.audit_logger:
+                self.audit_logger.log("ConfigurablePipeline", "policy_applied", {"results": len(results)})
 
         if self.trust_module:
             for res in results:
                 ctx = res.get("item", res)
                 presence = {k: bool(ctx.get(k)) for k in self.trust_module.weights}
                 res["trust"] = self.trust_module.calculate_trust(presence)
+            if self.audit_logger:
+                self.audit_logger.log("ConfigurablePipeline", "trust_calculated", {})
 
         if self.feedback_loop:
             actions = [r.get("prediction", {}) for r in results]
             suggestions = self.feedback_loop.suggest([], actions)
             for res, sugg in zip(results, suggestions):
                 res["goal_suggestion"] = sugg
+            if self.audit_logger:
+                self.audit_logger.log("ConfigurablePipeline", "feedback_suggested", {})
 
         return results

--- a/src/caiengine/pipelines/context_pipeline.py
+++ b/src/caiengine/pipelines/context_pipeline.py
@@ -4,10 +4,11 @@ from typing import List
 from caiengine.core.categorizer import Categorizer
 from caiengine.core.Deduplicars.fuzzy_deduplicator import FuzzyDeduplicator
 from caiengine.core.fuser import Fuser
+from caiengine.common import AuditLogger
 
 
 class ContextPipeline:
-    def __init__(self, context_provider, time_threshold_sec=5, fuzzy_threshold=0.8, merge_rule=None):
+    def __init__(self, context_provider, time_threshold_sec=5, fuzzy_threshold=0.8, merge_rule=None, audit_logger: AuditLogger | None = None):
         self.categorizer = Categorizer(context_provider)
         self.deduplicator = FuzzyDeduplicator(
             time_threshold_sec=time_threshold_sec,
@@ -15,15 +16,30 @@ class ContextPipeline:
             merge_rule=merge_rule,
         )
         self.fuser = Fuser()
+        self.audit_logger = audit_logger
 
     def run(self, data_batch: List[dict], candidates: List[dict]):
+        if self.audit_logger:
+            self.audit_logger.log("ContextPipeline", "run_start", {"items": len(data_batch), "candidates": len(candidates)})
+
         categorized = defaultdict(list)
         for item in data_batch:
             key = self.categorizer.categorize(item, candidates)
             categorized[key].append(item)
 
+        if self.audit_logger:
+            self.audit_logger.log("ContextPipeline", "categorized", {"categories": len(categorized)})
+
         deduped = {
             key: self.deduplicator.deduplicate(items) for key, items in categorized.items()
         }
 
-        return self.fuser.fuse(deduped)
+        if self.audit_logger:
+            self.audit_logger.log("ContextPipeline", "deduplicated", {"categories": len(deduped)})
+
+        fused = self.fuser.fuse(deduped)
+
+        if self.audit_logger:
+            self.audit_logger.log("ContextPipeline", "fused", {"result_count": len(fused)})
+
+        return fused

--- a/src/caiengine/pipelines/prompt_pipeline.py
+++ b/src/caiengine/pipelines/prompt_pipeline.py
@@ -10,6 +10,7 @@ from caiengine.interfaces.context_provider import ContextProvider
 from caiengine.interfaces.inference_engine import AIInferenceEngine
 from caiengine.objects.context_query import ContextQuery
 from caiengine.core.goal_feedback_loop import GoalDrivenFeedbackLoop
+from caiengine.common import AuditLogger
 
 
 class PromptPipeline:
@@ -28,6 +29,7 @@ class PromptPipeline:
         inference_engine: AIInferenceEngine,
         feedback_loop: Optional[GoalDrivenFeedbackLoop] = None,
         top_k: int = 3,
+        audit_logger: AuditLogger | None = None,
     ) -> None:
         self.provider = context_provider
         self.engine = inference_engine
@@ -37,14 +39,26 @@ class PromptPipeline:
         self.fuser = Fuser()
         self.feedback_loop = feedback_loop
         self.top_k = top_k
+        self.audit_logger = audit_logger
 
     def process(self, prompt: str, query: ContextQuery) -> Dict[str, any]:
         """Process ``prompt`` against stored context and return the inference result."""
+        if self.audit_logger:
+            self.audit_logger.log("PromptPipeline", "run_start", {})
+
         parsed = self.parser.transform(prompt)
+        if self.audit_logger:
+            self.audit_logger.log("PromptPipeline", "parsed", {})
+
         vec = self.encoder.encode(parsed)
         parsed["vector"] = vec
+        if self.audit_logger:
+            self.audit_logger.log("PromptPipeline", "encoded", {})
 
         all_ctx = self.provider.get_context(query)
+        if self.audit_logger:
+            self.audit_logger.log("PromptPipeline", "context_retrieved", {"count": len(all_ctx)})
+
         scored: List[Dict] = []
         for item in all_ctx:
             vec2 = item.get("vector")
@@ -54,10 +68,21 @@ class PromptPipeline:
             scored.append({"item": item, "score": score})
         scored.sort(key=lambda x: x["score"], reverse=True)
         top_items = [s["item"] for s in scored[: self.top_k]]
+        if self.audit_logger:
+            self.audit_logger.log("PromptPipeline", "scored", {"top_k": len(top_items)})
+
         fused = self.fuser.fuse({("prompt", "", ""): top_items})
+        if self.audit_logger:
+            self.audit_logger.log("PromptPipeline", "fused", {"result_count": len(fused)})
+
         result = self.engine.predict({"prompt": prompt, "context": fused})
+        if self.audit_logger:
+            self.audit_logger.log("PromptPipeline", "predicted", {})
+
         if self.feedback_loop:
             suggestions = self.feedback_loop.suggest([], [result])
             if suggestions:
                 result = suggestions[0]
+            if self.audit_logger:
+                self.audit_logger.log("PromptPipeline", "feedback_applied", {})
         return {"result": result, "parsed": parsed, "fused": fused}

--- a/src/caiengine/pipelines/question_pipeline.py
+++ b/src/caiengine/pipelines/question_pipeline.py
@@ -7,6 +7,7 @@ from caiengine.interfaces.context_provider import ContextProvider
 from caiengine.interfaces.inference_engine import AIInferenceEngine
 from caiengine.objects.context_query import ContextQuery
 from caiengine.core.goal_feedback_loop import GoalDrivenFeedbackLoop
+from caiengine.common import AuditLogger
 
 
 class QuestionPipeline:
@@ -25,6 +26,7 @@ class QuestionPipeline:
         inference_engine: AIInferenceEngine,
         feedback_loop: Optional[GoalDrivenFeedbackLoop] = None,
         top_k: int = 3,
+        audit_logger: AuditLogger | None = None,
     ):
         self.provider = context_provider
         self.engine = inference_engine
@@ -33,12 +35,19 @@ class QuestionPipeline:
         self.fuser = Fuser()
         self.feedback_loop = feedback_loop
         self.top_k = top_k
+        self.audit_logger = audit_logger
 
     def ask(self, question: str, query: ContextQuery, context: Optional[Dict] = None) -> Dict:
         """Return a suggested answer for ``question`` using optional ``context``."""
+        if self.audit_logger:
+            self.audit_logger.log("QuestionPipeline", "run_start", {})
+
         all_ctx = self.provider.get_context(query)
         q_features = context or {}
         q_vec = self.encoder.encode(q_features)
+        if self.audit_logger:
+            self.audit_logger.log("QuestionPipeline", "encoded", {})
+
         scored: List[Dict] = []
         for item in all_ctx:
             vec = item.get("vector")
@@ -48,10 +57,21 @@ class QuestionPipeline:
             scored.append({"item": item, "score": score})
         scored.sort(key=lambda x: x["score"], reverse=True)
         top_items = [s["item"] for s in scored[: self.top_k]]
+        if self.audit_logger:
+            self.audit_logger.log("QuestionPipeline", "scored", {"top_k": len(top_items)})
+
         fused = self.fuser.fuse({("qa", "", ""): top_items})
+        if self.audit_logger:
+            self.audit_logger.log("QuestionPipeline", "fused", {"result_count": len(fused)})
+
         answer = self.engine.predict({"question": question, "context": fused})
+        if self.audit_logger:
+            self.audit_logger.log("QuestionPipeline", "predicted", {})
+
         if self.feedback_loop:
             suggestions = self.feedback_loop.suggest([], [answer])
             if suggestions:
                 answer = suggestions[0]
+            if self.audit_logger:
+                self.audit_logger.log("QuestionPipeline", "feedback_applied", {})
         return {"answer": answer, "fused": fused}

--- a/src/caiengine/pipelines/sensor_pipeline.py
+++ b/src/caiengine/pipelines/sensor_pipeline.py
@@ -13,13 +13,14 @@ from typing import List
 from caiengine.core.categorizer import Categorizer
 from caiengine.core.Deduplicars.fuzzy_deduplicator import FuzzyDeduplicator
 from caiengine.core.fuser import Fuser
+from caiengine.common import AuditLogger
 
 
 class SensorPipeline:
     """Pipeline for processing sensor context data."""
 
     def __init__(self, context_provider, time_threshold_sec: int = 5,
-                 fuzzy_threshold: float = 0.8, merge_rule=None):
+                 fuzzy_threshold: float = 0.8, merge_rule=None, audit_logger: AuditLogger | None = None):
         self.categorizer = Categorizer(context_provider)
         self.deduplicator = FuzzyDeduplicator(
             time_threshold_sec=time_threshold_sec,
@@ -27,17 +28,32 @@ class SensorPipeline:
             merge_rule=merge_rule,
         )
         self.fuser = Fuser()
+        self.audit_logger = audit_logger
 
     def run(self, data_batch: List[dict], candidates: List[dict]):
         """Deduplicate, categorize and fuse a batch of sensor events."""
+
+        if self.audit_logger:
+            self.audit_logger.log("SensorPipeline", "run_start", {"items": len(data_batch), "candidates": len(candidates)})
 
         categorized = defaultdict(list)
         for item in data_batch:
             key = self.categorizer.categorize(item, candidates)
             categorized[key].append(item)
 
+        if self.audit_logger:
+            self.audit_logger.log("SensorPipeline", "categorized", {"categories": len(categorized)})
+
         deduped = {
             key: self.deduplicator.deduplicate(items) for key, items in categorized.items()
         }
 
-        return self.fuser.fuse(deduped)
+        if self.audit_logger:
+            self.audit_logger.log("SensorPipeline", "deduplicated", {"categories": len(deduped)})
+
+        fused = self.fuser.fuse(deduped)
+
+        if self.audit_logger:
+            self.audit_logger.log("SensorPipeline", "fused", {"result_count": len(fused)})
+
+        return fused

--- a/src/caiengine/pipelines/vector_pipeline.py
+++ b/src/caiengine/pipelines/vector_pipeline.py
@@ -6,6 +6,7 @@ from caiengine.core.Deduplicars.vector_deduplicator import VectorDeduplicator
 from caiengine.core.filters.kalman_filter import KalmanFilter
 from caiengine.interfaces.filter_strategy import FilterStrategy
 from caiengine.core.fuser import Fuser
+from caiengine.common import AuditLogger
 
 
 class VectorPipeline:
@@ -19,6 +20,7 @@ class VectorPipeline:
         time_threshold_sec: int = 5,
         vector_similarity_threshold: float = 0.1,
         merge_rule=None,
+        audit_logger: AuditLogger | None = None,
     ):
         self.categorizer = Categorizer(context_provider)
         filter_strategy = filter_strategy or KalmanFilter(vector_dim)
@@ -29,16 +31,31 @@ class VectorPipeline:
             merge_rule=merge_rule,
         )
         self.fuser = Fuser()
+        self.audit_logger = audit_logger
 
     def run(self, data_batch: List[dict], candidates: List[dict]):
+        if self.audit_logger:
+            self.audit_logger.log("VectorPipeline", "run_start", {"items": len(data_batch), "candidates": len(candidates)})
+
         categorized = defaultdict(list)
         for item in data_batch:
             key = self.categorizer.categorize(item, candidates)
             categorized[key].append(item)
+
+        if self.audit_logger:
+            self.audit_logger.log("VectorPipeline", "categorized", {"categories": len(categorized)})
 
         deduped = {
             key: self.deduplicator.deduplicate(items)
             for key, items in categorized.items()
         }
 
-        return self.fuser.fuse(deduped)
+        if self.audit_logger:
+            self.audit_logger.log("VectorPipeline", "deduplicated", {"categories": len(deduped)})
+
+        fused = self.fuser.fuse(deduped)
+
+        if self.audit_logger:
+            self.audit_logger.log("VectorPipeline", "fused", {"result_count": len(fused)})
+
+        return fused

--- a/tests/test_audit_logger.py
+++ b/tests/test_audit_logger.py
@@ -1,0 +1,12 @@
+from caiengine.common import AuditLogger
+from caiengine.pipelines.context_pipeline import ContextPipeline
+from caiengine.providers.mock_context_provider import MockContextProvider
+
+
+def test_audit_logger_tracks_steps():
+    audit = AuditLogger()
+    pipeline = ContextPipeline(MockContextProvider(), audit_logger=audit)
+    pipeline.run([], [])
+    steps = [r["step"] for r in audit.get_records() if r["pipeline"] == "ContextPipeline"]
+    assert "run_start" in steps
+    assert "fused" in steps


### PR DESCRIPTION
## Summary
- add AuditLogger utility to record pipeline step activity
- integrate audit logging across pipeline classes and configurable pipeline
- add unit test ensuring pipeline actions are logged

## Testing
- `pytest tests/test_audit_logger.py`
- `pytest` *(fails: KeyboardInterrupt after `tests/network/test_roboid_connection.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68c0450b8db0832abe4cb48e0a14b9fc