### PR TITLE
Add Docker-based agent simulation

### DIFF
--- a/simulation/README.md
+++ b/simulation/README.md
@@ -1,0 +1,13 @@
+# Simulation Environment
+
+This directory contains a simple Docker-based setup for running two example agents.
+
+## Usage
+
+Build and start the agents:
+
+```bash
+docker-compose up --build
+```
+
+The agents will print heartbeat messages to the console.

--- a/simulation/agents/agent-a/Dockerfile
+++ b/simulation/agents/agent-a/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY app.py .
+CMD ["python", "app.py"]

--- a/simulation/agents/agent-a/app.py
+++ b/simulation/agents/agent-a/app.py
@@ -1,0 +1,9 @@
+import os
+import time
+
+agent_id = os.getenv('AGENT_ID', 'agent-a')
+
+if __name__ == '__main__':
+    while True:
+        print(f"{agent_id}: running")
+        time.sleep(5)

--- a/simulation/agents/agent-b/Dockerfile
+++ b/simulation/agents/agent-b/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY app.py .
+CMD ["python", "app.py"]

--- a/simulation/agents/agent-b/app.py
+++ b/simulation/agents/agent-b/app.py
@@ -1,0 +1,9 @@
+import os
+import time
+
+agent_id = os.getenv('AGENT_ID', 'agent-b')
+
+if __name__ == '__main__':
+    while True:
+        print(f"{agent_id}: running")
+        time.sleep(5)

--- a/simulation/docker-compose.yml
+++ b/simulation/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.9'
+services:
+  agent-a:
+    build: ./agents/agent-a
+    environment:
+      - AGENT_ID=agent-a
+    networks:
+      - mesh
+  agent-b:
+    build: ./agents/agent-b
+    environment:
+      - AGENT_ID=agent-b
+    networks:
+      - mesh
+networks:
+  mesh:
+    driver: bridge


### PR DESCRIPTION
## Summary
- add `simulation` directory with Docker Compose for two example agents
- include simple Python agents and Dockerfiles for demonstration
- document how to start the simulation

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'torch')
- `pip install torch==2.3.1+cpu kafka-python==2.0.2` (fails: No matching distribution found for torch==2.3.1+cpu)


------
https://chatgpt.com/codex/tasks/task_e_68c1670cba5c832a88d12192417b3baf