### PR TITLE
feat: add transport-agnostic pub/sub network adapter

### DIFF
--- a/src/caiengine/network/__init__.py
+++ b/src/caiengine/network/__init__.py
@@ -9,8 +9,7 @@ from .roboid_connection import RoboIdConnection
 from .node_registry import NodeRegistry
 from .agent_network import AgentNetwork
 from .model_registry import ModelRegistry
-from .redis_pubsub_channel import RedisPubSubChannel
-from .kafka_pubsub_channel import KafkaPubSubChannel
+from .pubsub_network import PubSubNetwork
 
 __all__ = [
     "NetworkManager",
@@ -21,6 +20,19 @@ __all__ = [
     "NodeRegistry",
     "AgentNetwork",
     "ModelRegistry",
-    "RedisPubSubChannel",
-    "KafkaPubSubChannel",
+    "PubSubNetwork",
 ]
+
+try:  # Optional dependencies
+    from .redis_pubsub_channel import RedisPubSubChannel
+
+    __all__.append("RedisPubSubChannel")
+except Exception:  # pragma: no cover - optional dependency not installed
+    RedisPubSubChannel = None
+
+try:
+    from .kafka_pubsub_channel import KafkaPubSubChannel
+
+    __all__.append("KafkaPubSubChannel")
+except Exception:  # pragma: no cover - optional dependency not installed
+    KafkaPubSubChannel = None

--- a/src/caiengine/network/pubsub_network.py
+++ b/src/caiengine/network/pubsub_network.py
@@ -1,0 +1,64 @@
+"""NetworkInterface adapter using a pub/sub CommunicationChannel."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Callable, Dict, List, Tuple
+
+from caiengine.interfaces.network_interface import NetworkInterface
+from caiengine.interfaces.communication_channel import CommunicationChannel
+
+
+class PubSubNetwork(NetworkInterface):
+    """Adapt a :class:`CommunicationChannel` to the :class:`NetworkInterface` API.
+
+    Each node subscribes to its own topic as well as a shared broadcast topic.
+    Messages are queued internally so that ``receive`` can be polled by a
+    :class:`~caiengine.network.network_manager.NetworkManager`.
+    """
+
+    def __init__(self, channel: CommunicationChannel, node_id: str, broadcast_topic: str = "broadcast"):
+        self._channel = channel
+        self._node_id = node_id
+        self._broadcast_topic = broadcast_topic
+        self._messages: List[Tuple[str, Dict[str, Any]]] = []
+        self._lock = threading.Lock()
+        self._callback: Callable[[Dict[str, Any]], None] | None = None
+
+        # Subscribe to direct and broadcast topics.
+        self._channel.subscribe(node_id, self._create_handler(node_id))
+        if broadcast_topic:
+            self._channel.subscribe(broadcast_topic, self._create_handler("broadcast"))
+
+    def _create_handler(self, tag: str) -> Callable[[Dict[str, Any]], None]:
+        def handler(message: Dict[str, Any]) -> None:
+            with self._lock:
+                self._messages.append((tag, message))
+            if self._callback:
+                self._callback(message)
+        return handler
+
+    # -- NetworkInterface API -------------------------------------------------
+    def send(self, recipient_id: str, message: Dict[str, Any]):
+        self._channel.publish(recipient_id, message)
+
+    def broadcast(self, message: Dict[str, Any]):
+        self._channel.publish(self._broadcast_topic, message)
+
+    def receive(self) -> Tuple[str, Dict[str, Any]] | None:
+        with self._lock:
+            if self._messages:
+                return self._messages.pop(0)
+        return None
+
+    def start_listening(self, on_message_callback: Callable[[Dict[str, Any]], None]):
+        """Register a callback invoked for each incoming message."""
+        self._callback = on_message_callback
+
+    # Optional convenience to mirror ``SimpleNetworkMock``
+    def stop_listening(self):
+        """Unsubscribe from topics and clear the callback."""
+        self._channel.unsubscribe(self._node_id)
+        if self._broadcast_topic:
+            self._channel.unsubscribe(self._broadcast_topic)
+        self._callback = None

--- a/tests/network/test_pubsub_network.py
+++ b/tests/network/test_pubsub_network.py
@@ -1,0 +1,54 @@
+import time
+from typing import Any, Callable, Dict, List
+
+from caiengine.interfaces.communication_channel import CommunicationChannel
+from caiengine.network.pubsub_network import PubSubNetwork
+from caiengine.network.network_manager import NetworkManager
+
+
+class DummyChannel(CommunicationChannel):
+    def __init__(self):
+        self._subs: Dict[str, List[Callable[[Dict[str, Any]], None]]] = {}
+
+    def publish(self, topic: str, message: Dict[str, Any]) -> None:
+        for cb in list(self._subs.get(topic, [])):
+            cb(message)
+
+    def subscribe(self, topic: str, callback: Callable[[Dict[str, Any]], None]) -> None:
+        self._subs.setdefault(topic, []).append(callback)
+
+    def unsubscribe(self, topic: str) -> None:
+        self._subs.pop(topic, None)
+
+    def close(self) -> None:
+        self._subs.clear()
+
+
+def test_pubsub_network_send_receive():
+    channel = DummyChannel()
+    sender = PubSubNetwork(channel, "sender")
+    receiver = PubSubNetwork(channel, "receiver")
+    mgr = NetworkManager(receiver)
+    received: List[Dict[str, Any]] = []
+    mgr.start_listening(lambda msg: received.append(msg))
+
+    sender.send("receiver", {"hello": "world"})
+    time.sleep(0.05)
+    mgr.stop_listening()
+
+    assert {"hello": "world"} in received
+
+
+def test_pubsub_network_broadcast():
+    channel = DummyChannel()
+    broadcaster = PubSubNetwork(channel, "node1")
+    listener = PubSubNetwork(channel, "node2")
+    mgr = NetworkManager(listener)
+    received: List[Dict[str, Any]] = []
+    mgr.start_listening(lambda msg: received.append(msg))
+
+    broadcaster.broadcast({"foo": "bar"})
+    time.sleep(0.05)
+    mgr.stop_listening()
+
+    assert {"foo": "bar"} in received


### PR DESCRIPTION
## Summary
- add PubSubNetwork to adapt CommunicationChannel instances to the NetworkInterface
- expose PubSubNetwork and make Redis/Kafka channel imports optional
- cover pub/sub network messaging with unit tests

## Testing
- `CAIENGINE_LIGHT_IMPORT=1 pytest tests/network/test_pubsub_network.py`
- `CAIENGINE_LIGHT_IMPORT=1 pytest tests/network/test_network_manager_callback.py tests/network/test_context_bus.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1678c4cc8832aab64fe99c14c5de9