### PR TITLE
Add event context model with serialization

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ This project ships developer guides and design notes as static HTML files.
 
 - Open `dev/index.html` for developer-focused documentation.
 - Open `theory/index.html` for theoretical background and architecture notes.
+- See `event-context-standard.md` for the event/context data model.
 
 In the future these pages may move to a dedicated docs site (see
 [docs/dev/TECHNICAL_ROADMAP.md](dev/TECHNICAL_ROADMAP.md)).

--- a/docs/event-context-standard.md
+++ b/docs/event-context-standard.md
@@ -1,0 +1,58 @@
+# Event Context Standard
+
+This document defines a standard structure for representing events with
+multi-layered context and trust metadata.
+
+## Data model
+
+* **Event**
+  * `event_id`: unique identifier
+  * `timestamp`: epoch seconds
+  * `source`: origin system or actor
+  * `payload`: raw message or data
+  * `contexts`: mapping of context categories
+* **ContextCategory**
+  * `name`: category label such as `user`, `device`, or `environment`
+  * `layers`: ordered list of context layers
+* **ContextLayer**
+  * `layer_id`: identifier within the category
+  * `data`: arbitrary JSON-compatible payload
+  * `weight`: relevance weighting (0.0–1.0)
+  * `trust`: confidence score (0.0–1.0)
+  * `scope`: optional scope such as `global`, `session`, or `request`
+  * `parent`: optional parent layer identifier
+
+## Distribution
+
+Events and their context can be distributed as JSON documents. The
+structure is portable across languages and can be transported via message
+queues, HTTP APIs, or persisted to files. The default implementation
+uses JSON for ease of inspection and interoperability.
+
+## Persistence API
+
+The module `caiengine.common.context_model` provides classes for the data
+model and helper functions for persistence:
+
+```python
+from caiengine.common import Event, ContextCategory, ContextLayer
+
+layer = ContextLayer(layer_id="session", data={"user": "abc"}, weight=0.8)
+category = ContextCategory(name="user", layers=[layer])
+
+event = Event(
+    event_id="evt-1",
+    timestamp=1710000000.0,
+    source="sensor-A",
+    payload={"action": "login"},
+    contexts={"user": category},
+)
+
+# Save and load
+path = "event.json"
+event.save(path)
+loaded = Event.load(path)
+```
+
+This API allows components to persist or transmit events with their
+associated context in a standardized format.

--- a/src/caiengine/common/__init__.py
+++ b/src/caiengine/common/__init__.py
@@ -1,3 +1,9 @@
 from .audit_logger import AuditLogger
+from .context_model import ContextLayer, ContextCategory, Event
 
-__all__ = ["AuditLogger"]
+__all__ = [
+    "AuditLogger",
+    "ContextLayer",
+    "ContextCategory",
+    "Event",
+]

--- a/src/caiengine/common/context_model.py
+++ b/src/caiengine/common/context_model.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, List, Optional
+import json
+
+
+@dataclass
+class ContextLayer:
+    """Represents a single layer of context information."""
+
+    layer_id: str
+    data: Dict[str, Any]
+    weight: float = 1.0
+    trust: float = 1.0
+    scope: Optional[str] = None
+    parent: Optional[str] = None
+
+
+@dataclass
+class ContextCategory:
+    """Grouping for related context layers."""
+
+    name: str
+    layers: List[ContextLayer] = field(default_factory=list)
+
+
+@dataclass
+class Event:
+    """Event record carrying payload and related context."""
+
+    event_id: str
+    timestamp: float
+    source: str
+    payload: Dict[str, Any]
+    contexts: Dict[str, ContextCategory] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the event to a JSON-serializable dictionary."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Event":
+        """Recreate an :class:`Event` from a dictionary."""
+        contexts: Dict[str, ContextCategory] = {}
+        for name, cat in data.get("contexts", {}).items():
+            layers = [ContextLayer(**layer) for layer in cat.get("layers", [])]
+            contexts[name] = ContextCategory(name=name, layers=layers)
+        return cls(
+            event_id=data["event_id"],
+            timestamp=data["timestamp"],
+            source=data["source"],
+            payload=data.get("payload", {}),
+            contexts=contexts,
+        )
+
+    def save(self, path: str) -> None:
+        """Persist the event as JSON to ``path``."""
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(self.to_dict(), f, indent=2)
+
+    @classmethod
+    def load(cls, path: str) -> "Event":
+        """Load an event from JSON stored at ``path``."""
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return cls.from_dict(data)

--- a/tests/test_context_model.py
+++ b/tests/test_context_model.py
@@ -1,0 +1,40 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "context_model",
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "caiengine"
+    / "common"
+    / "context_model.py",
+)
+context_model = importlib.util.module_from_spec(spec)
+sys.modules["context_model"] = context_model
+spec.loader.exec_module(context_model)
+Event = context_model.Event
+ContextCategory = context_model.ContextCategory
+ContextLayer = context_model.ContextLayer
+
+
+def test_save_and_load_event(tmp_path):
+    layer = ContextLayer(
+        layer_id="layer1",
+        data={"key": "value"},
+        weight=0.5,
+        trust=0.9,
+    )
+    category = ContextCategory(name="user", layers=[layer])
+    event = Event(
+        event_id="evt-123",
+        timestamp=1710000000.0,
+        source="sensor",
+        payload={"foo": "bar"},
+        contexts={"user": category},
+    )
+
+    path = tmp_path / "event.json"
+    event.save(path)
+    loaded = Event.load(path)
+    assert loaded == event


### PR DESCRIPTION
## Summary
- add dataclasses for events, context categories, and layers
- support saving and loading events as JSON
- document event context standard and distribution

## Testing
- `pytest tests/test_context_model.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c16be0bbcc832aa9f13bebde935135