### PR TITLE
Enhance CAI bridge with marketing workflows and connector hooks

### DIFF
--- a/src/caiengine/cai_bridge.py
+++ b/src/caiengine/cai_bridge.py
@@ -1,12 +1,38 @@
 from __future__ import annotations
 
-from typing import List, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from caiengine.core.goal_feedback_loop import GoalDrivenFeedbackLoop
 from caiengine.core.goal_strategies import (
     SimpleGoalFeedbackStrategy,
     PersonalityGoalFeedbackStrategy,
+    MarketingGoalFeedbackStrategy,
 )
+from caiengine.commands import COMMAND
+
+
+class _SessionContextStore:
+    """In-memory helper for managing session metadata and attempts."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, Dict[str, Any]] = {}
+
+    def get_session(self, session_id: str) -> Dict[str, Any]:
+        session = self._store.setdefault(
+            session_id, {"metadata": {}, "attempts": {}}
+        )
+        return session
+
+    def update_metadata(self, session_id: str, updates: Dict[str, Any]) -> Dict[str, Any]:
+        session = self.get_session(session_id)
+        session["metadata"].update(updates)
+        return session
+
+    def increment_attempt(self, session_id: str, goal: str) -> int:
+        session = self.get_session(session_id)
+        attempts: Dict[str, int] = session.setdefault("attempts", {})
+        attempts[goal] = attempts.get(goal, 0) + 1
+        return attempts[goal]
 
 
 class CAIBridge:
@@ -17,8 +43,15 @@ class CAIBridge:
         goal_state: Optional[Dict] = None,
         personality: Optional[str] = None,
         one_direction_layers: Optional[List[str]] | None = None,
+        workflow: str | None = None,
+        marketing_config: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.goal_state = goal_state or {}
+        self._session_store = _SessionContextStore()
+        self._connector_registry: Any | None = None
+        self._persona_loader: Optional[Callable[[str], Dict[str, Any]]] = None
+        self._active_persona: Optional[Dict[str, Any]] = None
+        self._telemetry_handler: Optional[Callable[[Dict[str, Any]], None]] = None
         strategy = None
         if personality:
             strategy = PersonalityGoalFeedbackStrategy(
@@ -27,6 +60,12 @@ class CAIBridge:
             )
         elif one_direction_layers is not None:
             strategy = SimpleGoalFeedbackStrategy(one_direction_layers)
+        elif (workflow or "").lower() == "marketing":
+            strategy = MarketingGoalFeedbackStrategy(
+                config=marketing_config,
+                session_store=self._session_store,
+                telemetry_hook=self._emit_telemetry,
+            )
 
         self.feedback_loop = (
             GoalDrivenFeedbackLoop(strategy, goal_state=self.goal_state)
@@ -38,3 +77,87 @@ class CAIBridge:
         if self.feedback_loop:
             return self.feedback_loop.suggest(history, actions)
         return actions
+
+    # ------------------------------------------------------------------
+    # Integration hooks
+    # ------------------------------------------------------------------
+    def support_functions(
+        self,
+        *,
+        connector_registry: Any | None = None,
+        persona_loader: Optional[Callable[[str], Dict[str, Any]]] = None,
+        telemetry_handler: Optional[Callable[[Dict[str, Any]], None]] = None,
+    ) -> Dict[str, Callable[..., Any]]:
+        """Expose helpers that wire the bridge into a connector ecosystem.
+
+        Parameters
+        ----------
+        connector_registry:
+            Object responsible for routing :class:`COMMAND` payloads. The
+            object must expose either a ``dispatch`` or ``send`` method.
+        persona_loader:
+            Callable used to retrieve agent personas by identifier.
+        telemetry_handler:
+            Callable invoked with telemetry payloads emitted by strategies.
+        """
+
+        if connector_registry is not None:
+            self._connector_registry = connector_registry
+        if persona_loader is not None:
+            self._persona_loader = persona_loader
+        if telemetry_handler is not None:
+            self._telemetry_handler = telemetry_handler
+
+        def route_command(payload: Dict[str, Any]) -> Any:
+            if self._connector_registry is None:
+                raise RuntimeError("No connector registry configured")
+            command = payload.get("command")
+            if isinstance(command, COMMAND):
+                command_value = command.value
+            else:
+                command_value = str(command)
+
+            dispatcher = getattr(self._connector_registry, "dispatch", None)
+            if dispatcher is None:
+                dispatcher = getattr(self._connector_registry, "send", None)
+            if dispatcher is None:
+                raise AttributeError(
+                    "Connector registry must implement `dispatch` or `send`"
+                )
+            body = {k: v for k, v in payload.items() if k != "command"}
+            return dispatcher(command_value, body)
+
+        def load_persona(persona_id: str) -> Dict[str, Any]:
+            if self._persona_loader is None:
+                raise RuntimeError("No persona loader configured")
+            persona = self._persona_loader(persona_id)
+            if persona is None:
+                raise ValueError(f"Persona '{persona_id}' not found")
+            self._active_persona = persona
+            return persona
+
+        def session_context(
+            session_id: str, updates: Optional[Dict[str, Any]] = None
+        ) -> Dict[str, Any]:
+            session = self._session_store.get_session(session_id)
+            if updates:
+                self._session_store.update_metadata(session_id, updates)
+            return session
+
+        def emit_telemetry(event: Dict[str, Any]) -> Dict[str, Any]:
+            self._emit_telemetry(event)
+            return event
+
+        return {
+            "route_command": route_command,
+            "load_persona": load_persona,
+            "session_context": session_context,
+            "emit_telemetry": emit_telemetry,
+        }
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+    def _emit_telemetry(self, payload: Dict[str, Any]) -> None:
+        if self._telemetry_handler:
+            self._telemetry_handler(payload)

--- a/src/caiengine/commands.py
+++ b/src/caiengine/commands.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class COMMAND(str, Enum):
+    """Marketing-aware command primitives exposed to connectors."""
+
+    SEND_EMAIL = "send_email"
+    SCHEDULE_CALL = "schedule_call"
+    UPDATE_CRM = "update_crm"
+    ESCALATE = "escalate_to_human"
+    NOOP = "noop"
+
+
+__all__ = ["COMMAND"]

--- a/src/caiengine/core/goal_strategies/__init__.py
+++ b/src/caiengine/core/goal_strategies/__init__.py
@@ -2,5 +2,10 @@
 
 from .simple_goal_strategy import SimpleGoalFeedbackStrategy
 from .personality_goal_strategy import PersonalityGoalFeedbackStrategy
+from .marketing_goal_strategy import MarketingGoalFeedbackStrategy
 
-__all__ = ["SimpleGoalFeedbackStrategy", "PersonalityGoalFeedbackStrategy"]
+__all__ = [
+    "SimpleGoalFeedbackStrategy",
+    "PersonalityGoalFeedbackStrategy",
+    "MarketingGoalFeedbackStrategy",
+]

--- a/src/caiengine/core/goal_strategies/marketing_goal_strategy.py
+++ b/src/caiengine/core/goal_strategies/marketing_goal_strategy.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
+
+from caiengine.commands import COMMAND
+from caiengine.interfaces.goal_feedback_strategy import GoalFeedbackStrategy
+
+
+@dataclass(frozen=True)
+class EscalationRule:
+    name: str
+    keywords: Sequence[str] = field(default_factory=tuple)
+    goals: Sequence[str] = field(default_factory=tuple)
+    escalate_after: int = 1
+    actions: Sequence[Dict[str, Any]] = field(default_factory=tuple)
+
+
+DEFAULT_GOAL_LIBRARY: Dict[str, Dict[str, Any]] = {
+    "qualify_lead": {
+        "keywords": ["budget", "timeline", "decision"],
+        "actions": [
+            {
+                "command": COMMAND.UPDATE_CRM,
+                "metadata": {"stage": "qualification"},
+            },
+            {
+                "command": COMMAND.SEND_EMAIL,
+                "metadata": {
+                    "template": "lead_qualification",
+                },
+            },
+        ],
+        "insights": "Probe for buying intent and readiness to purchase.",
+    },
+    "address_churn": {
+        "keywords": ["cancel", "churn", "refund", "switch"],
+        "actions": [
+            {
+                "command": COMMAND.SEND_EMAIL,
+                "metadata": {
+                    "template": "churn_recovery",
+                },
+            },
+            {
+                "command": COMMAND.UPDATE_CRM,
+                "metadata": {"risk": "churn"},
+            },
+        ],
+        "insights": "Reassure the customer and offer retention incentives.",
+    },
+}
+
+
+DEFAULT_ESCALATION_RULES: Sequence[EscalationRule] = (
+    EscalationRule(
+        name="churn_escalation",
+        keywords=("cancel", "refund", "chargeback"),
+        goals=("address_churn",),
+        escalate_after=1,
+        actions=(
+            {
+                "command": COMMAND.ESCALATE,
+                "metadata": {"reason": "churn_risk"},
+            },
+        ),
+    ),
+    EscalationRule(
+        name="stalled_qualification",
+        goals=("qualify_lead",),
+        escalate_after=3,
+        actions=(
+            {
+                "command": COMMAND.SCHEDULE_CALL,
+                "metadata": {"priority": "high"},
+            },
+        ),
+    ),
+)
+
+
+class MarketingGoalFeedbackStrategy(GoalFeedbackStrategy):
+    """Strategy that maps qualitative marketing goals into concrete actions."""
+
+    def __init__(
+        self,
+        *,
+        config: Optional[Dict[str, Any]] = None,
+        session_store: Any | None = None,
+        telemetry_hook: Optional[Any] = None,
+    ) -> None:
+        config = config or {}
+        self.goal_library: Dict[str, Dict[str, Any]] = config.get(
+            "goal_library", DEFAULT_GOAL_LIBRARY
+        )
+        self.escalation_rules: Sequence[EscalationRule] = config.get(
+            "escalation_rules", DEFAULT_ESCALATION_RULES
+        )
+        self.session_store = session_store
+        self.telemetry_hook = telemetry_hook
+
+    # ------------------------------------------------------------------
+    # GoalFeedbackStrategy interface
+    # ------------------------------------------------------------------
+    def suggest_actions(
+        self,
+        history: List[Dict],
+        current_actions: List[Dict],
+        goal_state: Dict,
+    ) -> List[Dict]:
+        session_id = self._resolve_session_id(goal_state)
+        customer_text = self._extract_customer_text(history)
+        explicit_goals = set(goal_state.get("qualitative_targets", []))
+        detected_goals = self._detect_goals(customer_text, explicit_goals)
+
+        attempt_tracker: Dict[str, int] = defaultdict(int)
+        if self.session_store and session_id:
+            session = self.session_store.get_session(session_id)
+            attempt_tracker.update(session.get("attempts", {}))
+
+        updated_actions: List[Dict] = []
+        telemetry_payload: Dict[str, Any] = {
+            "session_id": session_id,
+            "detected_goals": list(detected_goals),
+            "escalations": [],
+        }
+
+        for action in current_actions:
+            enriched = dict(action)
+            marketing_plan: List[Dict[str, Any]] = []
+            escalations: List[Dict[str, Any]] = []
+
+            for goal in detected_goals:
+                attempt = self._increment_attempt(session_id, goal)
+                attempt_tracker[goal] = attempt
+
+                goal_config = self.goal_library.get(goal, {})
+                plan_step = {
+                    "goal": goal,
+                    "insights": goal_config.get("insights"),
+                    "actions": self._normalise_actions(goal_config.get("actions", [])),
+                    "attempt": attempt,
+                }
+                marketing_plan.append(plan_step)
+
+            escalations.extend(
+                self._evaluate_escalations(
+                    customer_text, detected_goals, attempt_tracker
+                )
+            )
+
+            if marketing_plan:
+                enriched["marketing_plan"] = marketing_plan
+            if escalations:
+                enriched.setdefault("commands", [])
+                enriched["commands"].extend(escalations)
+                telemetry_payload["escalations"].extend(escalations)
+            if marketing_plan and "commands" not in enriched:
+                enriched["commands"] = self._collect_commands(marketing_plan)
+            updated_actions.append(enriched)
+
+        if self.telemetry_hook and (telemetry_payload["detected_goals"] or telemetry_payload["escalations"]):
+            self.telemetry_hook(
+                {
+                    "type": "goal_feedback",
+                    **telemetry_payload,
+                }
+            )
+
+        return updated_actions or current_actions
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _resolve_session_id(goal_state: Dict[str, Any]) -> str:
+        if "session_id" in goal_state:
+            return str(goal_state["session_id"])
+        session = goal_state.get("session", {})
+        if isinstance(session, dict) and session.get("id"):
+            return str(session["id"])
+        return "default"
+
+    @staticmethod
+    def _extract_customer_text(history: List[Dict]) -> str:
+        customer_messages = []
+        for message in history:
+            role = message.get("role", "").lower()
+            if role in {"customer", "user", "prospect"}:
+                customer_messages.append(str(message.get("content", "")))
+        return " \n".join(customer_messages)
+
+    def _detect_goals(
+        self, customer_text: str, explicit_goals: Set[str]
+    ) -> Set[str]:
+        detected = set(explicit_goals)
+        lowered = customer_text.lower()
+        for goal, config in self.goal_library.items():
+            if goal in detected:
+                continue
+            keywords: Iterable[str] = config.get("keywords", [])
+            if any(keyword.lower() in lowered for keyword in keywords):
+                detected.add(goal)
+        return detected
+
+    def _increment_attempt(self, session_id: str, goal: str) -> int:
+        if not self.session_store:
+            return 1
+        return self.session_store.increment_attempt(session_id, goal)
+
+    def _evaluate_escalations(
+        self,
+        customer_text: str,
+        detected_goals: Set[str],
+        attempts: Dict[str, int],
+    ) -> List[Dict[str, Any]]:
+        lowered = customer_text.lower()
+        escalations: List[Dict[str, Any]] = []
+        for rule in self.escalation_rules:
+            keyword_triggered = any(
+                keyword.lower() in lowered for keyword in rule.keywords
+            )
+            goal_triggered = any(goal in detected_goals for goal in rule.goals)
+            if not (keyword_triggered or goal_triggered):
+                continue
+            if rule.goals:
+                max_attempt = max(attempts.get(goal, 0) for goal in rule.goals)
+            else:
+                max_attempt = 0
+            if max_attempt < rule.escalate_after:
+                continue
+            escalations.extend(self._normalise_actions(rule.actions))
+        return escalations
+
+    @staticmethod
+    def _normalise_actions(actions: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        normalised: List[Dict[str, Any]] = []
+        for action in actions:
+            if not action:
+                continue
+            if isinstance(action.get("command"), COMMAND):
+                command_value = action["command"].value
+            else:
+                command_value = str(action.get("command", COMMAND.NOOP.value))
+            payload = dict(action)
+            payload["command"] = command_value
+            normalised.append(payload)
+        return normalised
+
+    @staticmethod
+    def _collect_commands(plan: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        commands: List[Dict[str, Any]] = []
+        for step in plan:
+            commands.extend(step.get("actions", []))
+        return commands
+
+
+__all__ = [
+    "MarketingGoalFeedbackStrategy",
+    "EscalationRule",
+    "DEFAULT_GOAL_LIBRARY",
+    "DEFAULT_ESCALATION_RULES",
+]

--- a/tests/test_cai_bridge.py
+++ b/tests/test_cai_bridge.py
@@ -1,4 +1,9 @@
+import os
+
+os.environ.setdefault("CAIENGINE_LIGHT_IMPORT", "1")
+
 from caiengine.cai_bridge import CAIBridge
+from caiengine.commands import COMMAND
 
 
 def test_cai_bridge_personality_changes_suggestions():
@@ -9,3 +14,73 @@ def test_cai_bridge_personality_changes_suggestions():
     result_aggressive = aggressive.suggest(history, actions)[0]["progress"]
     result_cautious = cautious.suggest(history, actions)[0]["progress"]
     assert result_aggressive > result_cautious
+
+
+def test_marketing_workflow_generates_marketing_plan_and_escalation():
+    bridge = CAIBridge(
+        goal_state={
+            "session_id": "abc",
+            "qualitative_targets": ["address_churn"],
+        },
+        workflow="marketing",
+    )
+
+    history = [
+        {"role": "customer", "content": "I want to cancel if this is not fixed"}
+    ]
+    actions = [{}]
+
+    result = bridge.suggest(history, actions)[0]
+    assert "marketing_plan" in result
+    assert any(step["goal"] == "address_churn" for step in result["marketing_plan"])
+    assert any(
+        command["command"] == COMMAND.ESCALATE.value for command in result["commands"]
+    )
+
+
+def test_support_functions_wire_connectors_and_personas():
+    dispatched: list[tuple[str, dict]] = []
+
+    class DummyConnector:
+        def dispatch(self, command: str, payload: dict) -> None:
+            dispatched.append((command, payload))
+
+    loaded_personas = {}
+
+    def persona_loader(persona_id: str):
+        loaded_personas[persona_id] = {
+            "id": persona_id,
+            "tone": "friendly",
+        }
+        return loaded_personas[persona_id]
+
+    telemetry_events = []
+
+    def telemetry_handler(event):
+        telemetry_events.append(event)
+
+    bridge = CAIBridge(workflow="marketing")
+    support = bridge.support_functions(
+        connector_registry=DummyConnector(),
+        persona_loader=persona_loader,
+        telemetry_handler=telemetry_handler,
+    )
+
+    support["load_persona"]("advocate")
+    assert "advocate" in loaded_personas
+
+    support["session_context"]("sess-1", {"stage": "discovery"})
+    assert bridge.support_functions()["session_context"]("sess-1")["metadata"][
+        "stage"
+    ] == "discovery"
+
+    support["route_command"](
+        {
+            "command": COMMAND.SEND_EMAIL,
+            "payload": {"customer_id": 42},
+        }
+    )
+    assert dispatched == [(COMMAND.SEND_EMAIL.value, {"payload": {"customer_id": 42}})]
+
+    support["emit_telemetry"]({"type": "manual"})
+    assert telemetry_events[-1] == {"type": "manual"}


### PR DESCRIPTION
## Summary
- add a marketing goal feedback strategy that converts qualitative goals into marketing actions and escalation paths
- extend the CAI bridge with session tracking, telemetry support, and connector routing helpers
- expose a COMMAND enum so downstream connectors can execute structured marketing commands
- expand tests to cover marketing workflows and integration helpers

## Testing
- pytest tests/test_cai_bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68d82dfd12e0832ab164d53600d190b2