### PR TITLE
Add marketing conversation state tracking and adaptive automation

### DIFF
--- a/src/caiengine/core/marketing_coach.py
+++ b/src/caiengine/core/marketing_coach.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Sequence, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used only for type checking
+    from caiengine.parser.conversation_parser import ConversationState
+
+
+@dataclass
+class CoachingTip:
+    """Simple data structure returned by :class:`AdaptiveCoach`."""
+
+    message: str
+    priority: str = "normal"
+    category: str = "general"
+
+    def to_payload(self) -> Dict[str, Any]:
+        return {
+            "type": "coaching_tip",
+            "message": self.message,
+            "priority": self.priority,
+            "category": self.category,
+            "source": "adaptive_coach",
+        }
+
+
+class AdaptiveCoach:
+    """Generate coaching advice from conversation state and marketing plan."""
+
+    def __init__(
+        self,
+        *,
+        friction_threshold: int = 2,
+        unanswered_question_limit: int = 1,
+        long_turn_limit: int = 6,
+    ) -> None:
+        self.friction_threshold = friction_threshold
+        self.unanswered_question_limit = unanswered_question_limit
+        self.long_turn_limit = long_turn_limit
+
+    def generate(
+        self,
+        state: "ConversationState",
+        marketing_plan: Sequence[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        tips: List[CoachingTip] = []
+
+        if state.friction >= self.friction_threshold:
+            tips.append(
+                CoachingTip(
+                    message="Acknowledge the customer's frustration and reassure them of next steps.",
+                    priority="high",
+                    category="friction",
+                )
+            )
+
+        if state.open_questions and len(state.open_questions) >= self.unanswered_question_limit:
+            question = state.open_questions[0]
+            tips.append(
+                CoachingTip(
+                    message=f"Address the outstanding question: '{question}'",
+                    priority="high",
+                    category="open_question",
+                )
+            )
+
+        if state.metrics.get("customer_messages", 0) - state.metrics.get("agent_messages", 0) > 1:
+            tips.append(
+                CoachingTip(
+                    message="Balance the conversation by responding to the customer's latest message.",
+                    priority="medium",
+                    category="responsiveness",
+                )
+            )
+
+        if not marketing_plan:
+            tips.append(
+                CoachingTip(
+                    message="Clarify the customer's goals before proposing actions.",
+                    priority="medium",
+                    category="discovery",
+                )
+            )
+        else:
+            dominant_goal = marketing_plan[0].get("goal")
+            if dominant_goal == "address_churn":
+                tips.append(
+                    CoachingTip(
+                        message="Offer retention incentives or highlight recent improvements to keep the customer engaged.",
+                        priority="high",
+                        category="retention",
+                    )
+                )
+            elif dominant_goal == "qualify_lead":
+                tips.append(
+                    CoachingTip(
+                        message="Ask about timeline, budget, and decision makers to qualify the opportunity.",
+                        priority="medium",
+                        category="qualification",
+                    )
+                )
+
+        if state.metrics.get("total_messages", 0) >= self.long_turn_limit:
+            tips.append(
+                CoachingTip(
+                    message="Summarise progress and confirm the agreed next step to keep momentum.",
+                    priority="medium",
+                    category="momentum",
+                )
+            )
+
+        if state.last_customer_message:
+            tips.append(
+                CoachingTip(
+                    message=f"Reference the customer's last message to personalise your response: '{state.last_customer_message}'.",
+                    priority="low",
+                    category="personalisation",
+                )
+            )
+
+        return [tip.to_payload() for tip in tips]
+
+
+__all__ = ["AdaptiveCoach", "CoachingTip"]

--- a/src/caiengine/parser/__init__.py
+++ b/src/caiengine/parser/__init__.py
@@ -3,12 +3,24 @@
 
 from .log_parser import LogParser
 from .robo_connector_normalizer import RoboConnectorNormalizer
-from .prompt_parser import PromptParser
-from .intent_classifier import IntentClassifier
+from .conversation_parser import ConversationParser, ConversationState, ConversationTurn
+
+try:  # pragma: no cover - optional dependency chain
+    from .prompt_parser import PromptParser  # type: ignore
+except Exception:  # pragma: no cover - surface minimal parsers when deps missing
+    PromptParser = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency chain
+    from .intent_classifier import IntentClassifier  # type: ignore
+except Exception:  # pragma: no cover - optional when ML deps missing
+    IntentClassifier = None  # type: ignore
 
 __all__ = [
     "LogParser",
     "RoboConnectorNormalizer",
     "PromptParser",
     "IntentClassifier",
+    "ConversationParser",
+    "ConversationState",
+    "ConversationTurn",
 ]

--- a/src/caiengine/parser/conversation_parser.py
+++ b/src/caiengine/parser/conversation_parser.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Set
+
+
+_CUSTOMER_ROLES = {"customer", "user", "prospect", "lead"}
+_AGENT_ROLES = {"agent", "assistant", "coach", "system"}
+
+_POSITIVE_MARKERS = {"glad", "thanks", "great", "awesome", "perfect", "love"}
+_NEGATIVE_MARKERS = {
+    "angry",
+    "upset",
+    "frustrated",
+    "cancel",
+    "refund",
+    "disappointed",
+    "unhappy",
+    "terrible",
+    "issue",
+    "problem",
+}
+
+_STAGE_KEYWORDS: Sequence[tuple[str, Set[str]]] = (
+    ("retention", {"cancel", "refund", "churn", "switch"}),
+    ("decision", {"price", "purchase", "buy", "contract", "upgrade"}),
+    ("consideration", {"feature", "compare", "option", "plan", "demo"}),
+    ("awareness", {"problem", "need", "looking", "interest", "help"}),
+)
+
+_INTENT_KEYWORDS: Sequence[tuple[str, Set[str]]] = (
+    ("churn_risk", {"cancel", "refund", "switch"}),
+    ("pricing", {"price", "cost", "budget", "quote"}),
+    ("integration", {"integrate", "api", "connect", "system"}),
+    ("complaint", {"issue", "problem", "broken", "bug"}),
+)
+
+
+@dataclass
+class ConversationTurn:
+    role: str
+    content: str
+    sentiment: str
+    intents: List[str] = field(default_factory=list)
+    questions: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "role": self.role,
+            "content": self.content,
+            "sentiment": self.sentiment,
+            "intents": list(self.intents),
+            "questions": list(self.questions),
+        }
+
+
+@dataclass
+class ConversationState:
+    session_id: str
+    turns: List[ConversationTurn] = field(default_factory=list)
+    stage: str = "discovery"
+    sentiment: str = "neutral"
+    friction: int = 0
+    open_questions: List[str] = field(default_factory=list)
+    metrics: Dict[str, Any] = field(default_factory=dict)
+    tags: Set[str] = field(default_factory=set)
+    last_customer_message: Optional[str] = None
+    last_agent_message: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not self.metrics:
+            self.metrics = {
+                "total_messages": 0,
+                "customer_messages": 0,
+                "agent_messages": 0,
+                "question_count": 0,
+                "negative_markers": 0,
+            }
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "stage": self.stage,
+            "sentiment": self.sentiment,
+            "friction": self.friction,
+            "open_questions": list(self.open_questions),
+            "metrics": dict(self.metrics),
+            "tags": sorted(self.tags),
+            "last_customer_message": self.last_customer_message,
+            "last_agent_message": self.last_agent_message,
+            "turns": [turn.to_dict() for turn in self.turns[-10:]],
+        }
+
+
+class ConversationParser:
+    """Incrementally transform chat transcripts into stateful descriptors."""
+
+    def __init__(self) -> None:
+        self._states: Dict[str, ConversationState] = {}
+
+    def parse(self, session_id: str, history: List[Dict[str, Any]]) -> ConversationState:
+        state = self._states.setdefault(session_id, ConversationState(session_id=session_id))
+        processed = len(state.turns)
+        if processed > len(history):
+            # History rewound; rebuild from scratch
+            state = ConversationState(session_id=session_id)
+            processed = 0
+        for message in history[processed:]:
+            turn = self._normalise_turn(message)
+            state.turns.append(turn)
+            state.metrics["total_messages"] += 1
+            self._update_counts(state, turn)
+            self._update_stage(state, turn)
+            self._update_sentiment(state, turn)
+            self._update_questions(state, turn)
+            self._update_tags(state, turn)
+        self._states[session_id] = state
+        return state
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalise_turn(message: Dict[str, Any]) -> ConversationTurn:
+        role = str(message.get("role", "unknown")).lower()
+        content = str(message.get("content", "")).strip()
+        sentiment = ConversationParser._analyse_sentiment(content)
+        intents = ConversationParser._detect_intents(content)
+        questions = ConversationParser._extract_questions(content)
+        return ConversationTurn(role=role, content=content, sentiment=sentiment, intents=intents, questions=questions)
+
+    @staticmethod
+    def _analyse_sentiment(text: str) -> str:
+        lowered = text.lower()
+        positive_hits = sum(1 for marker in _POSITIVE_MARKERS if marker in lowered)
+        negative_hits = sum(1 for marker in _NEGATIVE_MARKERS if marker in lowered)
+        score = positive_hits - negative_hits
+        if negative_hits and score <= 0:
+            return "negative"
+        if score > 0:
+            return "positive"
+        if score < 0:
+            return "negative"
+        return "neutral"
+
+    @staticmethod
+    def _detect_intents(text: str) -> List[str]:
+        lowered = text.lower()
+        intents = []
+        for name, keywords in _INTENT_KEYWORDS:
+            if any(keyword in lowered for keyword in keywords):
+                intents.append(name)
+        return intents
+
+    @staticmethod
+    def _extract_questions(text: str) -> List[str]:
+        results = []
+        for match in re.finditer(r"([^?]+\?)", text):
+            question = match.group(1).strip()
+            if question:
+                results.append(question)
+        return results
+
+    @staticmethod
+    def _keywords(text: str) -> Set[str]:
+        tokens = re.findall(r"[a-zA-Z]{3,}", text.lower())
+        return {token for token in tokens if len(token) > 3}
+
+    def _update_counts(self, state: ConversationState, turn: ConversationTurn) -> None:
+        if turn.role in _CUSTOMER_ROLES:
+            state.metrics["customer_messages"] += 1
+            state.last_customer_message = turn.content or state.last_customer_message
+        elif turn.role in _AGENT_ROLES:
+            state.metrics["agent_messages"] += 1
+            state.last_agent_message = turn.content or state.last_agent_message
+        else:
+            state.metrics.setdefault("other_messages", 0)
+            state.metrics["other_messages"] += 1
+
+    def _update_stage(self, state: ConversationState, turn: ConversationTurn) -> None:
+        if turn.role not in _CUSTOMER_ROLES:
+            return
+        lowered = turn.content.lower()
+        for stage, keywords in _STAGE_KEYWORDS:
+            if any(keyword in lowered for keyword in keywords):
+                state.stage = stage
+                return
+        if state.stage == "discovery" and lowered:
+            state.stage = "discovery"
+
+    def _update_sentiment(self, state: ConversationState, turn: ConversationTurn) -> None:
+        if turn.sentiment == "negative":
+            state.friction += 1
+            state.metrics["negative_markers"] += 1
+            state.sentiment = "negative"
+        elif turn.sentiment == "positive":
+            state.sentiment = "positive"
+        elif state.sentiment == "neutral":
+            state.sentiment = turn.sentiment
+
+    def _update_questions(self, state: ConversationState, turn: ConversationTurn) -> None:
+        if turn.role in _CUSTOMER_ROLES and turn.questions:
+            state.open_questions.extend(turn.questions)
+            state.metrics["question_count"] += len(turn.questions)
+            return
+        if turn.role in _AGENT_ROLES and state.open_questions:
+            current_keywords = self._keywords(turn.content)
+            unresolved = []
+            for question in state.open_questions:
+                q_keywords = self._keywords(question)
+                if q_keywords and current_keywords.intersection(q_keywords):
+                    continue
+                unresolved.append(question)
+            state.open_questions = unresolved
+
+    @staticmethod
+    def _update_tags(state: ConversationState, turn: ConversationTurn) -> None:
+        if turn.intents:
+            state.tags.update(turn.intents)
+        if turn.questions:
+            state.tags.add("has_questions")
+        if turn.sentiment == "negative":
+            state.tags.add("friction")
+
+
+__all__ = ["ConversationParser", "ConversationState", "ConversationTurn"]

--- a/tests/test_conversation_parser.py
+++ b/tests/test_conversation_parser.py
@@ -1,0 +1,27 @@
+from caiengine.parser.conversation_parser import ConversationParser
+
+
+def test_conversation_parser_tracks_state_and_questions():
+    parser = ConversationParser()
+    session_id = "sess-123"
+    history = [
+        {"role": "customer", "content": "I am thinking about switching. What is the price?"},
+        {"role": "agent", "content": "We can offer a discount and the price is $10 per seat."},
+        {"role": "customer", "content": "Thanks, but I am still unhappy about the outage."},
+    ]
+
+    state = parser.parse(session_id, history[:1])
+    assert state.stage in {"decision", "consideration", "retention"}
+    assert state.metrics["customer_messages"] == 1
+    assert state.open_questions and "price" in state.open_questions[0].lower()
+
+    state = parser.parse(session_id, history[:2])
+    assert state.metrics["agent_messages"] == 1
+    assert not state.open_questions
+
+    state = parser.parse(session_id, history)
+    assert state.metrics["total_messages"] == 3
+    assert state.sentiment in {"negative", "neutral"}
+    assert state.friction >= 1
+    assert "friction" in state.tags
+    assert state.last_customer_message.endswith("outage.")

--- a/tests/test_marketing_coach.py
+++ b/tests/test_marketing_coach.py
@@ -1,0 +1,28 @@
+from caiengine.core.marketing_coach import AdaptiveCoach
+from caiengine.parser.conversation_parser import ConversationState
+
+
+def test_adaptive_coach_prioritises_friction_and_questions():
+    state = ConversationState(session_id="sess-1")
+    state.friction = 3
+    state.open_questions = ["Can you confirm the new price?"]
+    state.metrics["customer_messages"] = 3
+    state.metrics["agent_messages"] = 1
+    state.metrics["total_messages"] = 5
+    state.last_customer_message = "I am upset about the downtime."
+
+    plan = [
+        {
+            "goal": "address_churn",
+            "actions": [],
+        }
+    ]
+
+    tips = AdaptiveCoach().generate(state, plan)
+    messages = [tip["message"] for tip in tips]
+    priorities = {tip["priority"] for tip in tips}
+
+    assert any("frustration" in message.lower() for message in messages)
+    assert any("question" in message.lower() for message in messages)
+    assert "high" in priorities
+    assert any("personalise" in message.lower() for message in messages)


### PR DESCRIPTION
## Summary
- add a stateful conversation parser and adaptive marketing coach used by the marketing goal strategy
- enrich marketing feedback with coaching guidance, telemetry payloads, and automated escalation handling
- enable CAIBridge to auto-dispatch connector commands and cover the new behaviour with focused tests

## Testing
- CAIENGINE_LIGHT_IMPORT=1 pytest tests/test_conversation_parser.py tests/test_marketing_coach.py tests/test_cai_bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68dacaa8d89c832abae28ec49f345ada