### PR TITLE
Restore documentation and model management assets from main

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ This modular architecture is designed to evolve alongside AI needs, helping to r
 - Model Management: Replace, save, and load AI inference models at runtime
 - Goal-Driven Feedback Loop: Nudge actions toward user-defined goals via strategies like ``SimpleGoalFeedbackStrategy`` or ``PersonalityGoalFeedbackStrategy`` for NPC traits
 
+## Goal-Driven Feedback Use Cases
+
+- **Learning & Skill Development** – Adaptive tutoring that delivers targeted feedback based on learner goals.
+- **Workplace Training & Coaching** – On-the-job coaching that evaluates progress on objectives and offers actionable guidance.
+- **Project Planning & Productivity** – Planning tools that track milestones and suggest adjustments when goals drift.
+- **Code Review & Software Quality** – Automated review systems that assess pull requests against project goals and supply structured feedback.
+- **Creative Work & Content Generation** – Writing assistants that help meet publishing goals through suggestions on tone and style.
+- **Research & Data Analysis** – Tools that keep researchers aligned with hypothesis-driven objectives via methodological feedback.
+
 ## Documentation
 
 Developer guides live in the `docs/` directory. Open

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -45,3 +45,9 @@ Optional lightweight UI for browsing context history
 Developer guide for custom integrations
 Launch landing page & documentation site (e.g., with mkdocs or docsify)
 Goal-driven feedback loop for adjusting actions toward target context states *(see Technical Roadmap #24)*
+
+# 🧠 Phase 6: Model Management & Storage
+Target: v0.6+
+- Standardize model bundles around ONNX plus a context-aware manifest (see [docs/dev/model_storage_plan.md](docs/dev/model_storage_plan.md))
+- Provide tools for loading, migrating, and transporting models between environments
+- Enable a registry for discovering and retrieving context-aware models

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,8 +4,18 @@ This project ships developer guides and design notes as static HTML files.
 
 - Open `dev/index.html` for developer-focused documentation.
 - Open `theory/index.html` for theoretical background and architecture notes.
-- See `event-context-standard.md` for the event/context data model.
 
 In the future these pages may move to a dedicated docs site (see
 [docs/dev/TECHNICAL_ROADMAP.md](dev/TECHNICAL_ROADMAP.md)).
 
+
+## Mass Testing
+
+Before going live, stress test the goal feedback loop and learning pipeline with synthetic data:
+
+```bash
+pytest tests/test_goal_feedback_loop.py::test_goal_feedback_loop_randomized_batch \
+       tests/test_feedback_pipeline.py::TestFeedbackPipeline::test_feedback_pipeline_randomized_batch
+```
+
+These tests generate many fake context maps to ensure the system behaves correctly under load. Extend them as needed for your own scenarios.

--- a/docs/dev/goal_feedback_loop.md
+++ b/docs/dev/goal_feedback_loop.md
@@ -5,20 +5,11 @@ Client applications often need to steer actions toward a target without pausing 
 ## Background Worker
 Run the loop inside a background worker, service worker, or scheduled task. The worker should periodically poll for new actions or subscribe to an event stream.
 
-Use the scaffold in ``GoalFeedbackWorker`` as a starting point.
-TODO: implement real polling logic and persistence integration.
-
 ## State Tracking
 Persist the current goal state and any progress metrics in storage accessible by the worker (memory, local database, etc.). Update this state whenever goals change so the loop can compare new actions against the latest target.
 
-``GoalStateTracker`` currently stores data in memory only.
-TODO: hook this into a durable database or cache.
-
 ## Event-Driven Updates
 When a new action appears, send it to the worker through a queue or message channel. The worker computes suggestions only when history or goal state changes, limiting needless work.
-
-``FeedbackEventBus`` offers a minimal publish/subscribe interface.
-TODO: replace with an async queue or external message broker.
 
 ## Suggestion Logic
 Instantiate `GoalDrivenFeedbackLoop` with a strategy such as `SimpleGoalFeedbackStrategy` or `PersonalityGoalFeedbackStrategy`. Call `suggest_actions` with the current history and new actions to receive nudges toward the goal state.

--- a/docs/dev/model_storage_plan.md
+++ b/docs/dev/model_storage_plan.md
@@ -1,0 +1,36 @@
+# Model Storage & Registry Plan
+
+This document outlines the approach for Phase 6 of the project, delivering
+portable and context‑aware model bundles.
+
+## 1. Standard Representation
+
+- **ONNX as the core model format** for interoperability across runtimes.
+- A companion `manifest.yaml` or `manifest.toml` captures metadata such as
+  model name, version, training context, required preprocessing and
+  postprocessing steps, dependencies, and license details.
+
+## 2. Packaging
+
+- Package `model.onnx` and the manifest in a single archive (ZIP or OCI
+  artifact).
+- Optionally use content‑addressed or hashed file names to support
+  reproducibility.
+
+## 3. Tooling
+
+- Provide utilities to load, validate, and migrate bundles across
+  environments.
+- Include simple CLI helpers for exporting, importing, and verifying model
+  compatibility with the manifest.
+
+## 4. Registry Integration
+
+- Adopt a predictable bundle layout so a future registry can index manifest
+  fields for discovery.
+- Support context‑aware search and retrieval based on metadata such as
+  task, framework version, and required hardware.
+
+This plan establishes a portable "ONNX + manifest" standard, enabling
+consistent model management, transport, and discovery across the project.
+

--- a/docs/dev/network.html
+++ b/docs/dev/network.html
@@ -49,11 +49,7 @@
 <h2>NetworkManager</h2>
 <p>
   Wraps any <code>NetworkInterface</code> implementation and spawns a background
-  thread to deliver incoming messages. When provided with a
-  <code>NodeRegistry</code> it also lazily exposes mesh-aware helpers such as the
-  <code>NodeManager</code>, <code>CapabilityRegistry</code>, and
-  <code>MeshDispatcher</code>. This makes the class the central entry-point for
-  both transport-level and topology-level orchestration.
+  thread to deliver incoming messages.
 </p>
 
 <h2>SimpleNetworkMock</h2>
@@ -93,10 +89,7 @@ manager.update_context("task", {"status": "in_progress"})
 <p>
   <code>NodeRegistry</code> is a small utility that records active nodes in Redis.
   Each node registers its <em>RoboID</em> and network address, making discovery
-  of peers easy. Nodes can also be queried by RoboID fields such as role or
-  place to enable role-based addressing and filtering. See
-  <a href="roboid.html">RoboID Addressing</a> for details on the format and how
-  existing protocols are mapped into CaiEngine.
+  of peers easy.
 </p>
 
 <h2>Network-Aware Hooks</h2>

--- a/docs/theory/index.html
+++ b/docs/theory/index.html
@@ -30,6 +30,12 @@
       <li><strong>Multi-agent Decision Making:</strong> Coordinate tasks between AIs with awareness of each agent's role and environment.</li>
       <li><strong>Personalized Automation:</strong> Use context and trust layers to adapt workflows to individual users or machines.</li>
       <li><strong>Data Privacy Engines:</strong> Determine access rights based on context granularity and trust scores.</li>
+      <li><strong>Learning & Skill Development:</strong> Adaptive tutoring that gives targeted feedback based on learner goals.</li>
+      <li><strong>Workplace Training & Coaching:</strong> On-the-job coaching that evaluates performance on objectives and supplies guidance.</li>
+      <li><strong>Project Planning & Productivity:</strong> Collaborative tools that track progress toward milestones and suggest adjustments when goals drift.</li>
+      <li><strong>Code Review & Software Quality:</strong> Automated review systems that check pull requests against project goals and provide structured feedback.</li>
+      <li><strong>Creative Work & Content Generation:</strong> Writing assistants that help creators meet publishing goals with tone and style suggestions.</li>
+      <li><strong>Research & Data Analysis:</strong> Tools that keep researchers focused on hypotheses, offering methodological feedback.</li>
     </ul>
   </section>
 

--- a/src/caiengine/cli.py
+++ b/src/caiengine/cli.py
@@ -4,6 +4,7 @@ import importlib
 import logging
 from datetime import datetime
 from caiengine.objects.context_query import ContextQuery
+from caiengine.core import model_manager
 
 DEFAULT_PROVIDER = "providers.memory_context_provider.MemoryContextProvider"
 
@@ -38,6 +39,17 @@ def cmd_query(args):
     result = provider.get_context(query)
     logger.info(json.dumps(result, default=str, indent=2))
 
+def cmd_model_load(args):
+    model_manager.transport_model(args.source, args.dest)
+    if args.version and not model_manager.check_version(args.dest, args.version):
+        raise RuntimeError("Model version mismatch")
+
+def cmd_model_migrate(args):
+    model_manager.upgrade_schema(args.path, args.target_version)
+
+def cmd_model_export(args):
+    model_manager.transport_model(args.path, args.dest)
+
 def main(argv=None):
     logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser(prog="context")
@@ -58,12 +70,37 @@ def main(argv=None):
     query_p.add_argument("--scope", default="", help="Scope")
     query_p.add_argument("--data-type", default="", help="Data type")
 
+    model_p = sub.add_parser("model", help="Model operations")
+    model_sub = model_p.add_subparsers(dest="model_command")
+
+    load_p = model_sub.add_parser("load", help="Load model from source")
+    load_p.add_argument("--source", required=True, help="Source path or URL")
+    load_p.add_argument("--dest", required=True, help="Destination path")
+    load_p.add_argument("--version", default=None, help="Expected model version")
+
+    migrate_p = model_sub.add_parser("migrate", help="Migrate model schema")
+    migrate_p.add_argument("--path", required=True, help="Model file path")
+    migrate_p.add_argument("--target-version", required=True, help="Target schema version")
+
+    export_p = model_sub.add_parser("export", help="Export model to destination")
+    export_p.add_argument("--path", required=True, help="Model file path")
+    export_p.add_argument("--dest", required=True, help="Destination path")
+
     args = parser.parse_args(argv)
 
     if args.command == "add":
         cmd_add(args)
     elif args.command == "query":
         cmd_query(args)
+    elif args.command == "model":
+        if args.model_command == "load":
+            cmd_model_load(args)
+        elif args.model_command == "migrate":
+            cmd_model_migrate(args)
+        elif args.model_command == "export":
+            cmd_model_export(args)
+        else:
+            model_p.print_help()
     else:
         parser.print_help()
 

--- a/src/caiengine/common/token_usage.py
+++ b/src/caiengine/common/token_usage.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class TokenUsage:
+    """Simple data container tracking prompt and completion tokens."""
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+    def as_dict(self) -> dict:
+        return {
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "total_tokens": self.total_tokens,
+        }
+
+
+class TokenCounter:
+    """Aggregate token usage across multiple model invocations."""
+
+    def __init__(self) -> None:
+        self.usage = TokenUsage()
+
+    def add(self, usage: "TokenUsage | dict") -> None:
+        """Add a :class:`TokenUsage` or compatible dict to the aggregate."""
+        if isinstance(usage, dict):
+            usage = TokenUsage(**usage)
+        self.usage.prompt_tokens += usage.prompt_tokens
+        self.usage.completion_tokens += usage.completion_tokens
+
+    def reset(self) -> None:
+        """Reset the aggregate counts to zero."""
+        self.usage = TokenUsage()
+
+    def as_dict(self) -> dict:
+        return self.usage.as_dict()

--- a/src/caiengine/core/goal_strategies/marketing_goal_strategy.py
+++ b/src/caiengine/core/goal_strategies/marketing_goal_strategy.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
 
 from caiengine.commands import COMMAND
-from caiengine.interfaces.goal_feedback_strategy import GoalF
+from caiengine.interfaces.goal_feedback_strategy import GoalFeedbackStrategy
 from caiengine.parser.conversation_parser import ConversationParser, ConversationState
 from caiengine.core.marketing_coach import AdaptiveCoach
 

--- a/src/caiengine/core/model_bundle.py
+++ b/src/caiengine/core/model_bundle.py
@@ -1,0 +1,42 @@
+"""Utilities for exporting models to portable ONNX bundles."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn as nn
+import yaml
+
+from caiengine.objects.model_manifest import ModelManifest
+
+MODEL_ONNX_FILENAME = "model.onnx"
+MANIFEST_FILENAME = "manifest.yaml"
+
+
+def export_onnx_bundle(
+    model: nn.Module,
+    example_input: Any,
+    manifest: ModelManifest,
+    directory: str | Path,
+) -> None:
+    """Export ``model`` and its ``manifest`` into ``directory``.
+
+    The model is exported to ONNX format using the provided ``example_input`` to
+    trace the model graph. ``manifest`` is serialized to YAML.
+    """
+    dir_path = Path(directory)
+    dir_path.mkdir(parents=True, exist_ok=True)
+    torch.onnx.export(model, example_input, dir_path / MODEL_ONNX_FILENAME)
+    with open(dir_path / MANIFEST_FILENAME, "w", encoding="utf-8") as fh:
+        yaml.safe_dump(asdict(manifest), fh)
+
+
+def load_model_manifest(directory: str | Path) -> ModelManifest:
+    """Load a :class:`ModelManifest` from ``directory``."""
+    dir_path = Path(directory)
+    with open(dir_path / MANIFEST_FILENAME, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    return ModelManifest(**data)

--- a/src/caiengine/core/model_manager.py
+++ b/src/caiengine/core/model_manager.py
@@ -1,0 +1,47 @@
+import json
+import os
+import shutil
+from urllib.parse import urlparse
+from urllib.request import urlretrieve
+
+
+def _is_remote(path: str) -> bool:
+    parsed = urlparse(path)
+    return parsed.scheme in ("http", "https")
+
+
+def transport_model(src: str, dest: str) -> str:
+    """Copy or download a model file between storage backends.
+
+    If ``src`` is a remote URL (http/https) it will be downloaded to ``dest``.
+    Otherwise the file is copied locally.  The destination directory is
+    created if necessary.
+    """
+    os.makedirs(os.path.dirname(dest) or ".", exist_ok=True)
+    if _is_remote(src):
+        urlretrieve(src, dest)
+    else:
+        shutil.copy(src, dest)
+    return dest
+
+
+def check_version(path: str, expected: str) -> bool:
+    """Return True if the model file at ``path`` matches ``expected`` version."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data.get("version") == expected
+
+
+def upgrade_schema(path: str, target_version: str) -> None:
+    """Upgrade the model schema by setting its version fields.
+
+    The function reads the JSON model file at ``path`` and updates the
+    ``version`` and ``schema_version`` fields to ``target_version``.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    data["version"] = target_version
+    data["schema_version"] = target_version
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+

--- a/src/caiengine/core/model_storage.py
+++ b/src/caiengine/core/model_storage.py
@@ -1,0 +1,50 @@
+"""Utilities for persisting models with accompanying metadata."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Tuple, Type
+
+import torch
+import torch.nn as nn
+
+from caiengine.objects.model_metadata import ModelMetadata
+
+MODEL_FILENAME = "model.pt"
+METADATA_FILENAME = "metadata.json"
+
+
+def save_model_with_metadata(
+    model: nn.Module, metadata: ModelMetadata, directory: str | Path
+) -> None:
+    """Save ``model`` and ``metadata`` into ``directory``.
+
+    The model's ``state_dict`` is saved using :func:`torch.save` and the metadata
+    is serialized to JSON.
+    """
+    dir_path = Path(directory)
+    dir_path.mkdir(parents=True, exist_ok=True)
+    torch.save(model.state_dict(), dir_path / MODEL_FILENAME)
+    with open(dir_path / METADATA_FILENAME, "w", encoding="utf-8") as fh:
+        json.dump(asdict(metadata), fh)
+
+
+def load_model_with_metadata(
+    model_class: Type[nn.Module], directory: str | Path
+) -> Tuple[nn.Module, ModelMetadata]:
+    """Load a model and its metadata from ``directory``.
+
+    ``model_class`` should be instantiable without arguments. The returned model
+    will have its parameters loaded from the stored state dictionary.
+    """
+    dir_path = Path(directory)
+    with open(dir_path / METADATA_FILENAME, "r", encoding="utf-8") as fh:
+        meta_dict = json.load(fh)
+    metadata = ModelMetadata(**meta_dict)
+
+    model = model_class()
+    state = torch.load(dir_path / MODEL_FILENAME, map_location="cpu")
+    model.load_state_dict(state)
+    return model, metadata

--- a/src/caiengine/inference/token_usage_tracker.py
+++ b/src/caiengine/inference/token_usage_tracker.py
@@ -1,0 +1,65 @@
+import json
+from typing import Dict
+
+from caiengine.interfaces.inference_engine import AIInferenceEngine
+from caiengine.common.token_usage import TokenCounter, TokenUsage
+
+
+class TokenUsageTracker(AIInferenceEngine):
+    """Wrap an :class:`AIInferenceEngine` and record token usage for calls."""
+
+    def __init__(self, engine: AIInferenceEngine, counter: TokenCounter | None = None) -> None:
+        self.engine = engine
+        self.counter = counter or TokenCounter()
+
+    # ------------------------------------------------------------------
+    # utility helpers
+    # ------------------------------------------------------------------
+    def _count_tokens(self, text: str) -> int:
+        """Naive whitespace tokeniser used for usage accounting."""
+        return len(text.split()) if text else 0
+
+    # ------------------------------------------------------------------
+    # AIInferenceEngine interface
+    # ------------------------------------------------------------------
+    def infer(self, input_data: Dict) -> Dict:
+        result = self.engine.infer(input_data)
+        prompt_tokens = self._count_tokens(json.dumps(input_data))
+        completion_tokens = self._count_tokens(json.dumps(result))
+        usage = TokenUsage(prompt_tokens, completion_tokens)
+        self.counter.add(usage)
+        enriched = dict(result)
+        enriched["usage"] = usage.as_dict()
+        return enriched
+
+    def predict(self, input_data: Dict) -> Dict:
+        result = self.engine.predict(input_data)
+        if "usage" in result:
+            self.counter.add(result["usage"])
+            return result
+        prompt_tokens = self._count_tokens(json.dumps(input_data))
+        completion_tokens = self._count_tokens(json.dumps(result))
+        usage = TokenUsage(prompt_tokens, completion_tokens)
+        self.counter.add(usage)
+        enriched = dict(result)
+        enriched["usage"] = usage.as_dict()
+        return enriched
+
+    # delegate optional methods to underlying engine when available
+    def train(self, input_data: Dict, target: float) -> float:
+        return self.engine.train(input_data, target)
+
+    def replace_model(self, model, lr: float):
+        return self.engine.replace_model(model, lr)
+
+    def save_model(self, path: str):
+        return self.engine.save_model(path)
+
+    def load_model(self, path: str):
+        return self.engine.load_model(path)
+
+    # convenience accessor
+    @property
+    def usage(self) -> dict:
+        """Return aggregated token usage for this tracker."""
+        return self.counter.as_dict()

--- a/src/caiengine/network/model_registry.py
+++ b/src/caiengine/network/model_registry.py
@@ -1,0 +1,25 @@
+from typing import Any, Dict, List, Optional
+
+
+class ModelRegistry:
+    """Simple registry for storing and retrieving models.
+
+    The registry itself is backend agnostic and relies on a provided backend
+    object to persist entries.  The backend is expected to implement three
+    methods: ``register``, ``list`` and ``fetch``.
+    """
+
+    def __init__(self, backend: Any):
+        self.backend = backend
+
+    def register(self, model_id: str, version: str, data: Dict[str, Any]) -> None:
+        """Register a model entry with the underlying backend."""
+        self.backend.register(model_id, version, data)
+
+    def list(self) -> List[Dict[str, Any]]:
+        """Return all registered models from the backend."""
+        return self.backend.list()
+
+    def fetch(self, model_id: str, version: str) -> Optional[Dict[str, Any]]:
+        """Retrieve a model by identifier and version."""
+        return self.backend.fetch(model_id, version)

--- a/src/caiengine/objects/model_manifest.py
+++ b/src/caiengine/objects/model_manifest.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class ModelManifest:
+    """Manifest describing a portable model bundle."""
+
+    model_name: str
+    version: str
+    training_context: Optional[str] = None
+    preprocessing: List[str] = field(default_factory=list)
+    postprocessing: List[str] = field(default_factory=list)
+    dependencies: Dict[str, str] = field(default_factory=dict)
+    license: Optional[str] = None

--- a/src/caiengine/objects/model_metadata.py
+++ b/src/caiengine/objects/model_metadata.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class ModelMetadata:
+    """Metadata describing a persisted model."""
+
+    model_name: str
+    version: str
+    supported_context_types: List[str]
+    training_hash: str

--- a/src/caiengine/providers/__init__.py
+++ b/src/caiengine/providers/__init__.py
@@ -15,6 +15,7 @@ from .kafka_context_provider import KafkaContextProvider
 from .xml_context_provider import XMLContextProvider
 from .postgres_context_provider import PostgresContextProvider
 from .mysql_context_provider import MySQLContextProvider
+from .file_model_registry import FileModelRegistry
 
 __all__ = [
     "BaseContextProvider",
@@ -31,4 +32,5 @@ __all__ = [
     "XMLContextProvider",
     "PostgresContextProvider",
     "MySQLContextProvider",
+    "FileModelRegistry",
 ]

--- a/src/caiengine/providers/file_model_registry.py
+++ b/src/caiengine/providers/file_model_registry.py
@@ -1,0 +1,46 @@
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+
+class FileModelRegistry:
+    """File based backend for :class:`ModelRegistry`.
+
+    Each registered model is stored as a JSON file on disk using the naming
+    convention ``<model_id>-<version>.json``.
+    """
+
+    def __init__(self, folder_path: str):
+        self.folder_path = folder_path
+        os.makedirs(self.folder_path, exist_ok=True)
+
+    def _file_path(self, model_id: str, version: str) -> str:
+        safe_id = model_id.replace(os.sep, "_")
+        safe_version = version.replace(os.sep, "_")
+        filename = f"{safe_id}-{safe_version}.json"
+        return os.path.join(self.folder_path, filename)
+
+    def register(self, model_id: str, version: str, data: Dict[str, Any]) -> None:
+        """Persist model information to disk."""
+        path = self._file_path(model_id, version)
+        record = {"id": model_id, "version": version, "data": data}
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(record, f)
+
+    def list(self) -> List[Dict[str, Any]]:
+        """Return all models stored on disk."""
+        results: List[Dict[str, Any]] = []
+        for fname in os.listdir(self.folder_path):
+            if fname.endswith(".json"):
+                path = os.path.join(self.folder_path, fname)
+                with open(path, "r", encoding="utf-8") as f:
+                    results.append(json.load(f))
+        return results
+
+    def fetch(self, model_id: str, version: str) -> Optional[Dict[str, Any]]:
+        """Retrieve a specific model entry."""
+        path = self._file_path(model_id, version)
+        if not os.path.exists(path):
+            return None
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)

--- a/tests/ai_inference/test_token_usage_tracker.py
+++ b/tests/ai_inference/test_token_usage_tracker.py
@@ -1,0 +1,41 @@
+import importlib.util
+import pathlib
+import sys
+
+ROOT_DIR = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT_DIR))
+
+# import DummyAIInferenceEngine
+_dummy_spec = importlib.util.spec_from_file_location(
+    "dummy_engine", ROOT_DIR / "src" / "caiengine" / "inference" / "dummy_engine.py"
+)
+_dummy_module = importlib.util.module_from_spec(_dummy_spec)
+_dummy_spec.loader.exec_module(_dummy_module)
+DummyAIInferenceEngine = _dummy_module.DummyAIInferenceEngine
+
+# import TokenUsageTracker
+_tracker_spec = importlib.util.spec_from_file_location(
+    "token_usage_tracker", ROOT_DIR / "src" / "caiengine" / "inference" / "token_usage_tracker.py"
+)
+_tracker_module = importlib.util.module_from_spec(_tracker_spec)
+_tracker_spec.loader.exec_module(_tracker_module)
+TokenUsageTracker = _tracker_module.TokenUsageTracker
+
+
+def test_usage_counted_on_infer():
+    engine = TokenUsageTracker(DummyAIInferenceEngine())
+    data = {"text": "hello world"}
+    result = engine.infer(data)
+    assert "usage" in result
+    usage = result["usage"]
+    assert usage["prompt_tokens"] > 0
+    assert usage["completion_tokens"] > 0
+    assert engine.usage["total_tokens"] == usage["total_tokens"]
+
+
+def test_usage_accumulates_across_calls():
+    engine = TokenUsageTracker(DummyAIInferenceEngine())
+    engine.predict({"msg": "one two"})
+    first_total = engine.usage["total_tokens"]
+    engine.predict({"msg": "three four"})
+    assert engine.usage["total_tokens"] > first_total

--- a/tests/test_model_bundle.py
+++ b/tests/test_model_bundle.py
@@ -1,0 +1,61 @@
+import importlib.util
+import pathlib
+import sys
+import types
+
+import torch
+import torch.nn as nn
+
+
+SRC_ROOT = pathlib.Path(__file__).resolve().parents[1] / "src" / "caiengine"
+
+# Create lightweight package structure
+caiengine_pkg = types.ModuleType("caiengine")
+caiengine_pkg.__path__ = []
+sys.modules.setdefault("caiengine", caiengine_pkg)
+
+objects_pkg = types.ModuleType("caiengine.objects")
+objects_pkg.__path__ = []
+sys.modules.setdefault("caiengine.objects", objects_pkg)
+
+spec_manifest = importlib.util.spec_from_file_location(
+    "caiengine.objects.model_manifest", SRC_ROOT / "objects" / "model_manifest.py"
+)
+manifest_module = importlib.util.module_from_spec(spec_manifest)
+spec_manifest.loader.exec_module(manifest_module)
+sys.modules["caiengine.objects.model_manifest"] = manifest_module
+ModelManifest = manifest_module.ModelManifest
+
+core_pkg = types.ModuleType("caiengine.core")
+core_pkg.__path__ = []
+sys.modules.setdefault("caiengine.core", core_pkg)
+
+spec_bundle = importlib.util.spec_from_file_location(
+    "caiengine.core.model_bundle", SRC_ROOT / "core" / "model_bundle.py"
+)
+bundle_module = importlib.util.module_from_spec(spec_bundle)
+spec_bundle.loader.exec_module(bundle_module)
+export_onnx_bundle = bundle_module.export_onnx_bundle
+load_model_manifest = bundle_module.load_model_manifest
+
+
+class SimpleModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(2, 1)
+
+    def forward(self, x):  # pragma: no cover - not used
+        return self.linear(x)
+
+
+def test_export_and_load_manifest(tmp_path):
+    model = SimpleModel()
+    manifest = ModelManifest(model_name="simple", version="1.0")
+    dummy_input = torch.randn(1, 2)
+
+    export_onnx_bundle(model, dummy_input, manifest, tmp_path)
+
+    assert (tmp_path / "model.onnx").exists()
+    loaded = load_model_manifest(tmp_path)
+    assert loaded.model_name == manifest.model_name
+    assert loaded.version == manifest.version

--- a/tests/test_model_cli.py
+++ b/tests/test_model_cli.py
@@ -1,0 +1,72 @@
+import json
+import subprocess
+import sys
+import threading
+import http.server
+import socketserver
+import contextlib
+import os
+
+
+def run_cli(args, cwd=None):
+    src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, 'src'))
+    cli_path = os.path.join(src_path, 'caiengine', 'cli.py')
+    cmd = [sys.executable, cli_path] + args
+    env = os.environ.copy()
+    env['PYTHONPATH'] = src_path + os.pathsep + env.get('PYTHONPATH', '')
+    env['CAIENGINE_LIGHT_IMPORT'] = '1'
+    return subprocess.run(cmd, check=True, cwd=cwd, capture_output=True, env=env)
+
+
+@contextlib.contextmanager
+def run_server(directory):
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, directory=str(directory), **kwargs)
+
+    with socketserver.TCPServer(('127.0.0.1', 0), Handler) as httpd:
+        port = httpd.server_address[1]
+        thread = threading.Thread(target=httpd.serve_forever)
+        thread.daemon = True
+        thread.start()
+        try:
+            yield port
+        finally:
+            httpd.shutdown()
+            thread.join()
+
+
+def test_model_cli_local_workflow(tmp_path):
+    src = tmp_path / 'model_src.json'
+    with open(src, 'w', encoding='utf-8') as f:
+        json.dump({'version': '1.0', 'data': []}, f)
+
+    loaded = tmp_path / 'loaded.json'
+    run_cli(['model', 'load', '--source', str(src), '--dest', str(loaded), '--version', '1.0'])
+    assert loaded.exists()
+
+    run_cli(['model', 'migrate', '--path', str(loaded), '--target-version', '2.0'])
+    with open(loaded, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    assert data['version'] == '2.0'
+
+    exported = tmp_path / 'exported.json'
+    run_cli(['model', 'export', '--path', str(loaded), '--dest', str(exported)])
+    with open(exported, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    assert data['version'] == '2.0'
+
+
+def test_model_cli_remote_load(tmp_path):
+    remote_model = tmp_path / 'remote.json'
+    with open(remote_model, 'w', encoding='utf-8') as f:
+        json.dump({'version': '1.0'}, f)
+
+    with run_server(tmp_path) as port:
+        dest = tmp_path / 'download.json'
+        url = f'http://127.0.0.1:{port}/remote.json'
+        run_cli(['model', 'load', '--source', url, '--dest', str(dest)])
+        assert dest.exists()
+        with open(dest, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        assert data['version'] == '1.0'

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,44 @@
+import importlib.util
+import pathlib
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+# Dynamically load modules to avoid importing heavy package dependencies
+model_registry_spec = importlib.util.spec_from_file_location(
+    "model_registry", ROOT / "src" / "caiengine" / "network" / "model_registry.py"
+)
+model_registry_module = importlib.util.module_from_spec(model_registry_spec)
+model_registry_spec.loader.exec_module(model_registry_module)
+ModelRegistry = model_registry_module.ModelRegistry
+
+file_registry_spec = importlib.util.spec_from_file_location(
+    "file_model_registry", ROOT / "src" / "caiengine" / "providers" / "file_model_registry.py"
+)
+file_registry_module = importlib.util.module_from_spec(file_registry_spec)
+file_registry_spec.loader.exec_module(file_registry_module)
+FileModelRegistry = file_registry_module.FileModelRegistry
+
+
+class TestModelRegistry(unittest.TestCase):
+    def test_register_and_fetch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            backend = FileModelRegistry(tmp)
+            registry = ModelRegistry(backend)
+            registry.register("test-model", "1", {"value": 1})
+            registry.register("test-model", "2", {"value": 2})
+
+            models = registry.list()
+            self.assertEqual(len(models), 2)
+
+            fetched = registry.fetch("test-model", "2")
+            self.assertIsNotNone(fetched)
+            self.assertEqual(fetched["data"], {"value": 2})
+
+            fetched_old = registry.fetch("test-model", "1")
+            self.assertEqual(fetched_old["data"], {"value": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_model_storage_format.py
+++ b/tests/test_model_storage_format.py
@@ -1,0 +1,83 @@
+import importlib.util
+import json
+import pathlib
+import sys
+import types
+from dataclasses import asdict
+
+import torch
+import torch.nn as nn
+
+# Set up lightweight package structure to avoid importing heavy dependencies
+SRC_ROOT = pathlib.Path(__file__).resolve().parents[1] / "src" / "caiengine"
+
+caiengine_pkg = types.ModuleType("caiengine")
+caiengine_pkg.__path__ = []
+sys.modules.setdefault("caiengine", caiengine_pkg)
+
+objects_pkg = types.ModuleType("caiengine.objects")
+objects_pkg.__path__ = []
+sys.modules.setdefault("caiengine.objects", objects_pkg)
+
+spec_meta = importlib.util.spec_from_file_location(
+    "caiengine.objects.model_metadata", SRC_ROOT / "objects" / "model_metadata.py"
+)
+model_metadata_module = importlib.util.module_from_spec(spec_meta)
+spec_meta.loader.exec_module(model_metadata_module)
+sys.modules["caiengine.objects.model_metadata"] = model_metadata_module
+ModelMetadata = model_metadata_module.ModelMetadata
+
+core_pkg = types.ModuleType("caiengine.core")
+core_pkg.__path__ = []
+sys.modules.setdefault("caiengine.core", core_pkg)
+
+spec_storage = importlib.util.spec_from_file_location(
+    "caiengine.core.model_storage", SRC_ROOT / "core" / "model_storage.py"
+)
+model_storage_module = importlib.util.module_from_spec(spec_storage)
+spec_storage.loader.exec_module(model_storage_module)
+save_model_with_metadata = model_storage_module.save_model_with_metadata
+load_model_with_metadata = model_storage_module.load_model_with_metadata
+
+
+class SimpleModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(2, 1)
+
+    def forward(self, x):  # pragma: no cover - not used in tests
+        return self.linear(x)
+
+
+def create_sample_model_and_metadata():
+    model = SimpleModel()
+    with torch.no_grad():
+        model.linear.weight.fill_(1.0)
+        model.linear.bias.fill_(0.5)
+
+    metadata = ModelMetadata(
+        model_name="simple",
+        version="1.0",
+        supported_context_types=["text", "image"],
+        training_hash="abc123",
+    )
+    return model, metadata
+
+
+def test_round_trip_save_load(tmp_path):
+    model, metadata = create_sample_model_and_metadata()
+    save_model_with_metadata(model, metadata, tmp_path)
+
+    loaded_model, loaded_meta = load_model_with_metadata(SimpleModel, tmp_path)
+
+    assert asdict(loaded_meta) == asdict(metadata)
+    for p_orig, p_loaded in zip(model.parameters(), loaded_model.parameters()):
+        assert torch.equal(p_orig, p_loaded)
+
+
+def test_metadata_integrity(tmp_path):
+    model, metadata = create_sample_model_and_metadata()
+    save_model_with_metadata(model, metadata, tmp_path)
+    with open(tmp_path / "metadata.json", "r", encoding="utf-8") as fh:
+        on_disk = json.load(fh)
+    assert on_disk == asdict(metadata)


### PR DESCRIPTION
## Summary
- restore the project README, roadmap, and developer docs that were removed in the network merge
- reintroduce the token usage tracking utilities together with their regression tests
- bring back the model bundle/storage/registry modules (and supporting CLI/service code) needed for model management

## Testing
- pytest tests/test_model_registry.py
- pytest tests/ai_inference/test_token_usage_tracker.py *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68dad93e9308832ab5b72a640208b38a