### PR TITLE
Fix network package exports for registries

### DIFF
--- a/src/caiengine/network/__init__.py
+++ b/src/caiengine/network/__init__.py
@@ -18,6 +18,9 @@ from .heartbeats import HeartbeatStore
 from .node_tasks import NodeTask, NodeTaskQueue, RedisNodeTaskQueue
 from .node_agent import NodeAgent
 from .discovery import NodeDiscoveryService, WebSocketDiscoveryClient
+from .model_registry import ModelRegistry
+from .redis_pubsub_channel import RedisPubSubChannel
+from .kafka_pubsub_channel import KafkaPubSubChannel
 
 __all__ = [
     "NetworkManager",
@@ -44,4 +47,7 @@ __all__ = [
     "NodeAgent",
     "NodeDiscoveryService",
     "WebSocketDiscoveryClient",
+    "ModelRegistry",
+    "RedisPubSubChannel",
+    "KafkaPubSubChannel",
 ]


### PR DESCRIPTION
## Summary
- expose the model registry and pub/sub channel helpers from the network package so legacy imports remain functional

## Testing
- pytest -vv --cov=caiengine --cov-report=xml *(fails: missing optional dependencies numpy, redis, torch)*

------
https://chatgpt.com/codex/tasks/task_e_68dae2837270832a835d4d2482333ae4