### PR TITLE
Add conversation parser entity extraction and discourse tracking

### DIFF
--- a/tests/test_conversation_parser.py
+++ b/tests/test_conversation_parser.py
@@ -25,3 +25,39 @@ def test_conversation_parser_tracks_state_and_questions():
     assert state.friction >= 1
     assert "friction" in state.tags
     assert state.last_customer_message.endswith("outage.")
+
+
+def test_conversation_parser_extracts_entities_slots_and_discourse():
+    parser = ConversationParser()
+    session_id = "sess-entities"
+    history = [
+        {"role": "customer", "content": "Hi, I'm Alice from Acme Corp. My email is alice@example.com."},
+        {
+            "role": "agent",
+            "content": "Hi Alice, thanks for sharing. What issue are you seeing with the analytics dashboard?",
+        },
+        {
+            "role": "customer",
+            "content": "The analytics dashboard crashes on login. It happens every morning at 9am.",
+        },
+        {"role": "agent", "content": "Got it. We'll involve engineering on the dashboard issue."},
+        {
+            "role": "customer",
+            "content": "Also, the price needs to stay at $99 per month for our contract.",
+        },
+    ]
+
+    state = parser.parse(session_id, history)
+
+    # Entity recognition aggregates person, company, and contact details
+    assert "alice@example.com" in state.entities.get("email", set())
+    assert any(name.startswith("Alice") for name in state.entities.get("person", set()))
+    assert any(company.startswith("Acme") for company in state.entities.get("company", set()))
+
+    # Slot filling identifies price commitments and the main issue being discussed
+    assert any(value.startswith("$99") for value in state.slots.get("price", set()))
+    assert any("dashboard" in issue.lower() for issue in state.slots.get("issue", set()))
+
+    # Discourse tracking links pronouns back to the referenced topic
+    pronoun_links = state.discourse.get("pronoun_links", [])
+    assert any("dashboard" in link["entity"].lower() for link in pronoun_links)


### PR DESCRIPTION
## Summary
- add heuristic entity extraction, slot filling, and discourse tracking to the conversation parser state machine
- expose aggregated entities, slots, and discourse links on `ConversationState` and persist them on each turn for downstream use
- add a regression test that exercises entity extraction, slot detection, and pronoun resolution across a short dialogue

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68db703ddfd4832a9e4e35b2164a90e3