### PR TITLE
Allow configuring HTTP service backend providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ python -m caiengine.service
 
 The server binds to `0.0.0.0:8080` by default. Set `CAI_ENGINE_ENDPOINT` in your application to this URL to reuse the running service instead of spawning `cai_bridge.py` repeatedly.
 
+You can choose an alternative backend provider by supplying the class path and optional keyword arguments:
+
+```bash
+python -m caiengine.service \
+  --backend caiengine.providers.sqlite_context_provider.SQLiteContextProvider \
+  --backend-options '{"db_path": "./context.db"}'
+```
+
 ### Environment Variables
 
 Copy `.env.example` to `.env` and adjust the values as needed. The file includes

--- a/tests/test_http_context_provider.py
+++ b/tests/test_http_context_provider.py
@@ -5,9 +5,25 @@ from urllib import request, parse
 
 from caiengine.providers.http_context_provider import HTTPContextProvider
 from caiengine.objects.context_query import ContextQuery
+from caiengine.providers.memory_context_provider import MemoryContextProvider
 
 
 class TestHTTPContextProvider(unittest.TestCase):
+    def test_prepare_backend_from_path(self):
+        provider = HTTPContextProvider(
+            backend="caiengine.providers.simple_context_provider.SimpleContextProvider"
+        )
+        self.assertTrue(hasattr(provider.backend, "ingest_context"))
+        self.assertTrue(hasattr(provider.backend, "get_context"))
+
+    def test_prepare_backend_from_config(self):
+        backend_config = {
+            "path": "caiengine.providers.memory_context_provider.MemoryContextProvider",
+            "options": {},
+        }
+        provider = HTTPContextProvider(backend=backend_config)
+        self.assertIsInstance(provider.backend, MemoryContextProvider)
+
     def test_post_and_get(self):
         provider = HTTPContextProvider(host="127.0.0.1", port=8099)
         provider.start()


### PR DESCRIPTION
## Summary
- allow `HTTPContextProvider` to instantiate backend providers from string paths or configuration dictionaries
- expose backend configuration as a `caiengine.service` option and document usage in the README
- add unit tests covering backend preparation behaviour for the HTTP provider

## Testing
- CAIENGINE_LIGHT_IMPORT=1 pytest tests/test_http_context_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68dbcba12024832a92d92d455d4d6aa2