### PR TITLE
Add optional SQL storage extras and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,22 @@ Developer guides live in the `docs/` directory. Open
    pytest
    ```
 
+### Optional storage drivers
+
+The built-in providers cover in-memory storage and SQLite without any extra
+dependencies. To persist context to external databases, install the optional
+extras when setting up the package:
+
+- **MySQL** – `pip install .[mysql]` installs
+  `mysql-connector-python` for `MySQLContextProvider`.
+- **PostgreSQL** – `pip install .[postgresql]` installs
+  `psycopg2-binary` for `PostgresContextProvider`.
+- **All SQL backends** – `pip install .[storage]` pulls in the full set of
+  SQL connectors so you can switch providers without reinstalling.
+
+Once the desired driver is installed you can point the service or pipeline to
+the corresponding provider class (e.g. `caiengine.providers.mysql_context_provider.MySQLContextProvider`).
+
 You can now start implementing your own `ContextProvider` or test the built-in ones.
 
 ### Starting the Service

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,12 @@ dependencies = [
 [project.optional-dependencies]
 redis = ["redis>=6.1.0"]
 kafka = ["kafka-python>=2.0.2"]
+mysql = ["mysql-connector-python>=9.1.0"]
+postgresql = ["psycopg2-binary>=2.9.10"]
+storage = [
+    "mysql-connector-python>=9.1.0",
+    "psycopg2-binary>=2.9.10",
+]
 dev = [
     "pytest>=8.3.5",
     "pytest-cov>=4.1.0",

--- a/src/caiengine/pipelines/configurable_pipeline.py
+++ b/src/caiengine/pipelines/configurable_pipeline.py
@@ -10,6 +10,7 @@ from caiengine.providers import (
     XMLContextProvider,
     SQLiteContextProvider,
     MySQLContextProvider,
+    PostgresContextProvider,
     MemoryContextProvider,
 )
 from caiengine.interfaces.context_provider import ContextProvider
@@ -28,6 +29,8 @@ _PROVIDER_MAP = {
     "xml": XMLContextProvider,
     "sqlite": SQLiteContextProvider,
     "mysql": MySQLContextProvider,
+    "postgres": PostgresContextProvider,
+    "postgresql": PostgresContextProvider,
     "memory": lambda **kwargs: ContextProvider(**kwargs),
 }
 


### PR DESCRIPTION
## Summary
- add optional dependency groups for MySQL and PostgreSQL connectors plus a combined storage extra
- document how to install the optional SQL drivers in the README
- expose the Postgres context provider through the configurable pipeline helper

## Testing
- pytest *(fails: missing optional dependencies such as numpy, redis, and torch in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc20557ad0832aaf59796af782a8ee