### PR TITLE
Add neural embedding based categorizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,28 @@ result = categorizer.categorize(item)
 print(result["category"], result["confidence"])
 ```
 
+### Neural Embedding Categorization
+
+For richer semantic matching initialise ``NeuralEmbeddingCategorizer`` with a
+handful of example phrases per category.  The categorizer builds prototype
+embeddings and returns softmax-normalised confidences without any additional
+training.
+
+```python
+from caiengine.core.categorizer import NeuralEmbeddingCategorizer
+
+categorizer = NeuralEmbeddingCategorizer(
+    {
+        "sales": ("Closing a deal", "Following up with a prospect"),
+        "support": ("Investigating a ticket", "Escalating a customer bug"),
+    }
+)
+
+item = {"content": "Working on an urgent ticket for a key customer"}
+result = categorizer.categorize(item)
+print(result["category"], result["confidence"])
+```
+
 ### Configurable Pipeline
 
 The `ConfigurablePipeline` ties providers, policies and optional feedback loops

--- a/src/caiengine/core/__init__.py
+++ b/src/caiengine/core/__init__.py
@@ -12,7 +12,11 @@ if not os.environ.get("CAIENGINE_LIGHT_IMPORT"):
     from .context_hooks import ContextHookManager, ContextHook
     from .fuser import Fuser
     from .policy_evaluator import PolicyEvaluator
-    from .categorizer import Categorizer, NeuralKeywordCategorizer
+    from .categorizer import (
+        Categorizer,
+        NeuralKeywordCategorizer,
+        NeuralEmbeddingCategorizer,
+    )
     from .text_embeddings import (
         SimpleTextCategorizer,
         HashingTextEmbedder,
@@ -43,6 +47,7 @@ if not os.environ.get("CAIENGINE_LIGHT_IMPORT"):
         "PolicyEvaluator",
         "Categorizer",
         "NeuralKeywordCategorizer",
+        "NeuralEmbeddingCategorizer",
         "SimpleTextCategorizer",
         "HashingTextEmbedder",
         "TextEmbeddingComparer",

--- a/tests/test_neural_embedding_categorizer.py
+++ b/tests/test_neural_embedding_categorizer.py
@@ -1,0 +1,62 @@
+import os
+
+import pytest
+
+os.environ.setdefault("CAIENGINE_LIGHT_IMPORT", "1")
+
+pytest.importorskip("torch")
+
+from caiengine.core.categorizer import NeuralEmbeddingCategorizer
+
+
+@pytest.fixture()
+def embedding_categorizer() -> NeuralEmbeddingCategorizer:
+    return NeuralEmbeddingCategorizer(
+        {
+            "sales": (
+                "Closing a high value deal with an enterprise prospect",
+                "Following up with a promising pipeline opportunity",
+            ),
+            "support": (
+                "Resolving a customer ticket with a serious outage",
+                "Investigating a bug report escalated by support",
+            ),
+        }
+    )
+
+
+def test_sales_item_scores_highest(embedding_categorizer: NeuralEmbeddingCategorizer) -> None:
+    item = {
+        "content": "Meeting with the sales team to close a new prospect deal",
+        "tags": ["pipeline", "deal"],
+    }
+
+    result = embedding_categorizer.categorize(item)
+
+    assert result["category"] == "sales"
+    assert set(result["scores"]) == {"sales", "support"}
+    assert pytest.approx(sum(result["scores"].values()), rel=1e-6) == 1.0
+
+
+def test_support_item_scores_highest(
+    embedding_categorizer: NeuralEmbeddingCategorizer,
+) -> None:
+    item = {
+        "content": "Working through an urgent customer ticket about an outage",
+        "keywords": ["ticket", "outage"],
+    }
+
+    result = embedding_categorizer.categorize(item)
+
+    assert result["category"] == "support"
+    assert result["scores"]["support"] > result["scores"]["sales"]
+
+
+def test_unknown_category_when_no_text(
+    embedding_categorizer: NeuralEmbeddingCategorizer,
+) -> None:
+    result = embedding_categorizer.categorize({})
+
+    assert result["category"] == embedding_categorizer.unknown_category
+    assert result["confidence"] == 0.0
+    assert result["scores"] == {}


### PR DESCRIPTION
## Summary
- add a neural embedding categorizer that bootstraps weights from example phrases
- expose the new categorizer through the core module and document how to use it
- cover the categorizer with unit tests that skip when PyTorch is unavailable

## Testing
- `pytest` *(fails: environment lacks optional dependencies such as numpy/redis/torch)*
- `pytest tests/test_neural_embedding_categorizer.py -q` *(skipped: PyTorch not installed in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcdf62a6c4832a97c5f3e7fef80d84