### PR TITLE
Add OCR context provider and metadata support

### DIFF
--- a/docs/dev/ocr_to_structured_data.md
+++ b/docs/dev/ocr_to_structured_data.md
@@ -44,6 +44,20 @@ module) that reads OCR output (files, API responses, or database rows) and yield
 By keeping these signals inside the context, CAIEngine modules can incorporate
 confidence and structural hints rather than relying on regexes.
 
+### 2.1 Use the Built-in `OCRContextProvider`
+
+The repository now ships with an `OCRContextProvider` that implements the
+pattern above. It accepts raw OCR text, optional `display_text`, confidence
+scores, and either `OCRSpan` objects or dictionaries describing bounding boxes.
+Each ingested document is stored in a `ContextData` record with the
+`ocr_metadata` field populated so downstream modules can access both the
+structured payload and the spatial metadata.
+
+If you already have OCR spans represented as dictionaries, pass them directly to
+`ingest_ocr_document`; they will be normalised into strongly-typed `OCRSpan`
+instances. This simplifies integrating new OCR sources without rewriting your
+data mapping logic.
+
 ## 3. Smarter Categorization than Regex
 
 Instead of regular expressions, leverage the `TextEmbeddingComparer` plus your

--- a/src/caiengine/objects/__init__.py
+++ b/src/caiengine/objects/__init__.py
@@ -6,6 +6,7 @@ from .context_query import ContextQuery
 from .fused_context import FusedContext
 from .model_metadata import ModelMetadata
 from .model_manifest import ModelManifest
+from .ocr_metadata import OCRMetadata, OCRSpan
 
 __all__ = [
     "ContextData",
@@ -14,4 +15,6 @@ __all__ = [
     "FusedContext",
     "ModelMetadata",
     "ModelManifest",
+    "OCRMetadata",
+    "OCRSpan",
 ]

--- a/src/caiengine/objects/context_data.py
+++ b/src/caiengine/objects/context_data.py
@@ -1,7 +1,9 @@
-from typing import Protocol, Callable, List
+from typing import Protocol, Callable, List, Optional
 from dataclasses import dataclass
 from datetime import datetime
 from uuid import UUID
+
+from .ocr_metadata import OCRMetadata
 
 @dataclass
 class ContextData:
@@ -13,6 +15,7 @@ class ContextData:
     situations: List[str]
     content: any
     confidence: float = 1.0
+    ocr_metadata: Optional[OCRMetadata] = None
 
 
 SubscriptionHandle = UUID

--- a/src/caiengine/objects/ocr_metadata.py
+++ b/src/caiengine/objects/ocr_metadata.py
@@ -1,0 +1,115 @@
+"""Data structures representing OCR metadata for context payloads."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+
+__all__ = ["OCRMetadata", "OCRSpan", "BoundingBox", "OffsetRange"]
+
+
+BoundingBox = Tuple[float, float, float, float]
+OffsetRange = Tuple[int, int]
+
+
+@dataclass
+class OCRSpan:
+    """Represents a candidate OCR field with spatial metadata."""
+
+    field_name: str
+    value: str
+    bbox: Optional[BoundingBox] = None
+    page_number: Optional[int] = None
+    confidence: Optional[float] = None
+    offsets: Optional[OffsetRange] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the span to a serialisable dictionary."""
+
+        data: Dict[str, Any] = {
+            "field_name": self.field_name,
+            "value": self.value,
+        }
+        if self.bbox is not None:
+            data["bbox"] = self.bbox
+        if self.page_number is not None:
+            data["page_number"] = self.page_number
+        if self.confidence is not None:
+            data["confidence"] = self.confidence
+        if self.offsets is not None:
+            data["offsets"] = self.offsets
+        if self.extra:
+            data["extra"] = self.extra
+        return data
+
+
+@dataclass
+class OCRMetadata:
+    """Container for OCR-specific payload signals."""
+
+    raw_text: str
+    document_type_hint: Optional[str] = None
+    display_text: Optional[str] = None
+    spans: List[OCRSpan] = field(default_factory=list)
+    confidence_scores: Dict[str, float] = field(default_factory=dict)
+    language: Optional[str] = None
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+    def to_payload(self) -> Dict[str, Any]:
+        """Create a payload dict suitable for storage in :class:`ContextData`."""
+
+        payload: Dict[str, Any] = {
+            "text": self.raw_text,
+            "display_text": self.display_text or self.raw_text,
+            "document_type_hint": self.document_type_hint,
+            "spans": [span.to_dict() for span in self.spans],
+            "confidence_scores": self.confidence_scores,
+        }
+        if self.language is not None:
+            payload["language"] = self.language
+        if self.extras:
+            payload["extras"] = self.extras
+        return payload
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialise the metadata into a dictionary, keeping structured spans."""
+
+        data = self.to_payload()
+        data["spans"] = [span.to_dict() for span in self.spans]
+        return data
+
+    @classmethod
+    def normalise_spans(
+        cls, spans: Optional[Sequence[Union["OCRSpan", Dict[str, Any]]]]
+    ) -> List["OCRSpan"]:
+        """Coerce dictionaries into :class:`OCRSpan` instances."""
+
+        if not spans:
+            return []
+
+        normalised: List[OCRSpan] = []
+        for span in spans:
+            if isinstance(span, OCRSpan):
+                normalised.append(span)
+                continue
+
+            if not isinstance(span, dict):
+                raise TypeError(
+                    "OCR spans must be OCRSpan instances or dictionaries; "
+                    f"received {type(span)!r}."
+                )
+
+            normalised.append(
+                OCRSpan(
+                    field_name=span.get("field_name") or span.get("field", ""),
+                    value=span.get("value", ""),
+                    bbox=span.get("bbox"),
+                    page_number=span.get("page_number"),
+                    confidence=span.get("confidence"),
+                    offsets=span.get("offsets"),
+                    extra=span.get("extra", {}),
+                )
+            )
+        return normalised
+

--- a/src/caiengine/providers/__init__.py
+++ b/src/caiengine/providers/__init__.py
@@ -16,6 +16,7 @@ from .xml_context_provider import XMLContextProvider
 from .postgres_context_provider import PostgresContextProvider
 from .mysql_context_provider import MySQLContextProvider
 from .file_model_registry import FileModelRegistry
+from .ocr_context_provider import OCRContextProvider
 
 __all__ = [
     "BaseContextProvider",
@@ -33,4 +34,5 @@ __all__ = [
     "PostgresContextProvider",
     "MySQLContextProvider",
     "FileModelRegistry",
+    "OCRContextProvider",
 ]

--- a/src/caiengine/providers/memory_context_provider.py
+++ b/src/caiengine/providers/memory_context_provider.py
@@ -1,9 +1,10 @@
 import uuid
 from datetime import datetime
-from typing import List, Union
+from typing import List, Union, Optional
 
 from caiengine.core.cache_manager import CacheManager
 from caiengine.objects.context_data import ContextData
+from caiengine.objects.ocr_metadata import OCRMetadata
 from caiengine.objects.context_query import ContextQuery
 from .base_context_provider import BaseContextProvider
 
@@ -23,6 +24,7 @@ class MemoryContextProvider(BaseContextProvider):
             source_id: str = "memory",
             confidence: float = 1.0,
             ttl: Union[int, None] = None,
+            ocr_metadata: Optional[OCRMetadata] = None,
     ) -> str:
         """Store a new context entry and notify subscribers."""
         context_id = str(uuid.uuid4())
@@ -35,6 +37,7 @@ class MemoryContextProvider(BaseContextProvider):
             roles=(metadata or {}).get("roles", []),
             situations=(metadata or {}).get("situations", []),
             content=(metadata or {}).get("content", ""),
+            ocr_metadata=ocr_metadata,
         )
         self.cache.set(context_id, cd, ttl)
         super().publish_context(cd)
@@ -63,4 +66,5 @@ class MemoryContextProvider(BaseContextProvider):
             "content": cd.content,
             "context": cd.payload,
             "confidence": cd.confidence,
+            "ocr_metadata": cd.ocr_metadata.to_dict() if cd.ocr_metadata else None,
         }

--- a/src/caiengine/providers/ocr_context_provider.py
+++ b/src/caiengine/providers/ocr_context_provider.py
@@ -1,0 +1,69 @@
+"""Context provider specialised for OCR-ingested documents."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
+
+from caiengine.objects.context_query import ContextQuery
+from caiengine.objects.ocr_metadata import OCRMetadata, OCRSpan
+
+from .memory_context_provider import MemoryContextProvider
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from caiengine.objects.context_data import ContextData
+
+
+class OCRContextProvider(MemoryContextProvider):
+    """Store OCR payloads with spatial metadata for downstream modules."""
+
+    def ingest_ocr_document(
+        self,
+        raw_text: str,
+        *,
+        display_text: Optional[str] = None,
+        document_type_hint: Optional[str] = None,
+        spans: Optional[Sequence[Union[OCRSpan, Dict[str, Any]]]] = None,
+        confidence_scores: Optional[Dict[str, float]] = None,
+        language: Optional[str] = None,
+        extras: Optional[Dict[str, Any]] = None,
+        timestamp: Optional[datetime] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        source_id: str = "ocr",
+        confidence: float = 1.0,
+    ) -> str:
+        """Ingest OCR data and broadcast a :class:`ContextData` instance."""
+
+        ocr_metadata = OCRMetadata(
+            raw_text=raw_text,
+            display_text=display_text,
+            document_type_hint=document_type_hint,
+            spans=OCRMetadata.normalise_spans(spans),
+            confidence_scores=confidence_scores or {},
+            language=language,
+            extras=extras or {},
+        )
+
+        payload = ocr_metadata.to_payload()
+        enriched_metadata = dict(metadata or {})
+        if "roles" not in enriched_metadata:
+            enriched_metadata["roles"] = []
+        if "situations" not in enriched_metadata:
+            enriched_metadata["situations"] = []
+        if "content" not in enriched_metadata:
+            enriched_metadata["content"] = payload["text"]
+
+        return super().ingest_context(
+            payload=payload,
+            timestamp=timestamp,
+            metadata=enriched_metadata,
+            source_id=source_id,
+            confidence=confidence,
+            ocr_metadata=ocr_metadata,
+        )
+
+    def get_structured_context(self, query: ContextQuery) -> List["ContextData"]:
+        """Return raw :class:`ContextData` records for advanced OCR consumers."""
+
+        return self.fetch_context(query)
+

--- a/src/caiengine/providers/simple_context_provider.py
+++ b/src/caiengine/providers/simple_context_provider.py
@@ -1,9 +1,10 @@
 import uuid
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 import caiengine.objects.context_data as ContextData
 import caiengine.objects.context_query as ContextQuery
+from caiengine.objects.ocr_metadata import OCRMetadata
 from .base_context_provider import BaseContextProvider
 
 
@@ -21,6 +22,7 @@ class SimpleContextProvider(BaseContextProvider):
         metadata: dict | None = None,
         source_id: str = "simple",
         confidence: float = 1.0,
+        ocr_metadata: Optional[OCRMetadata] = None,
     ) -> str:
         context_id = str(uuid.uuid4())
         cd = ContextData.ContextData(
@@ -32,6 +34,7 @@ class SimpleContextProvider(BaseContextProvider):
             roles=(metadata or {}).get("roles", []),
             situations=(metadata or {}).get("situations", []),
             content=(metadata or {}).get("content", ""),
+            ocr_metadata=ocr_metadata,
         )
         self._data.append(cd)
         super().publish_context(cd)
@@ -57,4 +60,5 @@ class SimpleContextProvider(BaseContextProvider):
             "content": cd.content,
             "context": cd.payload,
             "confidence": cd.confidence,
+            "ocr_metadata": cd.ocr_metadata.to_dict() if cd.ocr_metadata else None,
         }

--- a/tests/test_ocr_context_provider.py
+++ b/tests/test_ocr_context_provider.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+
+from caiengine.objects.context_query import ContextQuery
+from caiengine.objects.ocr_metadata import OCRSpan
+from caiengine.providers.ocr_context_provider import OCRContextProvider
+
+
+def test_ingest_ocr_document_emits_context():
+    provider = OCRContextProvider()
+    received = []
+    provider.subscribe_context(received.append)
+
+    span = OCRSpan(
+        field_name="invoice_number",
+        value="INV-001",
+        bbox=(0.1, 0.2, 0.3, 0.4),
+        page_number=1,
+        confidence=0.92,
+        offsets=(10, 17),
+    )
+
+    provider.ingest_ocr_document(
+        raw_text="Invoice INV-001 total $123.45",
+        document_type_hint="invoice",
+        spans=[span],
+        confidence_scores={"document": 0.87},
+        language="en",
+    )
+
+    assert len(received) == 1
+    context = received[0]
+    assert context.payload["text"].startswith("Invoice INV-001")
+    assert context.payload["document_type_hint"] == "invoice"
+    assert context.ocr_metadata is not None
+    assert context.ocr_metadata.spans[0].field_name == "invoice_number"
+    assert context.ocr_metadata.confidence_scores["document"] == 0.87
+
+
+def test_fetch_structured_context_includes_spans():
+    provider = OCRContextProvider()
+
+    provider.ingest_ocr_document(
+        raw_text="Resume: Jane Doe",
+        document_type_hint="resume",
+        spans=[
+            {
+                "field_name": "candidate_name",
+                "value": "Jane Doe",
+                "bbox": (0.0, 0.0, 0.5, 0.1),
+                "confidence": 0.99,
+            }
+        ],
+    )
+
+    query = ContextQuery(
+        roles=[],
+        time_range=(datetime.min, datetime.max),
+        scope="*",
+        data_type="*",
+    )
+
+    contexts = provider.get_structured_context(query)
+    assert len(contexts) == 1
+    payload_spans = contexts[0].payload["spans"]
+    assert payload_spans[0]["field_name"] == "candidate_name"
+    assert contexts[0].ocr_metadata.spans[0].value == "Jane Doe"


### PR DESCRIPTION
## Summary
- add dedicated OCR metadata structures and expose them via ContextData
- introduce an OCRContextProvider that normalises spans and shares OCR-aware payloads
- update existing providers, docs, and tests to propagate ocr_metadata information

## Testing
- pytest
- pytest tests/test_ocr_context_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68dd488e344c832aafb385e387da6d09