### PR TITLE
Extend SVG example set with desert and medic assets

### DIFF
--- a/docs/examples/svg_library/README.md
+++ b/docs/examples/svg_library/README.md
@@ -13,12 +13,24 @@ svg_library/
   characters/
     hero.svg
     hero.meta.json
+    drone.svg
+    drone.meta.json
+    field_medic.svg
+    field_medic.meta.json
   backgrounds/
     cityscape.svg
     cityscape.meta.yaml
+    forest_glade.svg
+    forest_glade.meta.yaml
+    desert_canyon.svg
+    desert_canyon.meta.yaml
   effects/
     sun_glow.svg
     sun_glow.meta.json
+    energy_ring.svg
+    energy_ring.meta.json
+    signal_wave.svg
+    signal_wave.meta.json
 ```
 
 Each SVG is organised into semantic `<g>` groups whose `id` attributes encode
@@ -28,7 +40,10 @@ prompts can reference reusable colour schemes without editing raw hex values.
 The metadata sidecars summarise the visual intent of each group, record bounding
 box hints, and list any palettes or blend modes that downstream tools should
 apply. These files can be ingested into a context map under a `visual_assets`
-channel so the language model can plan compositions.
+channel so the language model can plan compositions. The expanded library now
+covers nature and desert backdrops, multiple support characters, and layered
+energy effects so the prompting examples can show how to mix and match multiple
+styles.
 
 ## Sample Context Packet Entry
 

--- a/docs/examples/svg_library/backgrounds/desert_canyon.meta.yaml
+++ b/docs/examples/svg_library/backgrounds/desert_canyon.meta.yaml
@@ -1,0 +1,23 @@
+summary: Warm desert canyon with layered mesas and sunlit dunes.
+groups:
+  - id: desert_canyon/sky
+    role: dawn sky gradient with soft sun
+    bounding_box: { x: 0, y: 0, width: 320, height: 120 }
+  - id: desert_canyon/mesas-back
+    role: distant mesas for parallax depth
+    bounding_box: { x: 0, y: 90, width: 320, height: 110 }
+  - id: desert_canyon/mesas-front
+    role: midground rock formations
+    bounding_box: { x: 0, y: 110, width: 320, height: 100 }
+  - id: desert_canyon/sand
+    role: foreground dune sweep
+    bounding_box: { x: 0, y: 150, width: 320, height: 50 }
+palette_tokens:
+  - --sky-dawn
+  - --sky-horizon
+  - --rock-sunlit
+  - --rock-shadow
+  - --sand-light
+recommended_usage:
+  - Adventure or sci-fi desert backdrop
+  - Combine with hover vehicles or explorers for cinematic depth

--- a/docs/examples/svg_library/backgrounds/desert_canyon.svg
+++ b/docs/examples/svg_library/backgrounds/desert_canyon.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 200">
+  <defs>
+    <linearGradient id="canyon-sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="var(--sky-dawn, #f6c27a)" />
+      <stop offset="100%" stop-color="var(--sky-horizon, #f3e3c9)" />
+    </linearGradient>
+    <linearGradient id="canyon-rock" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="var(--rock-sunlit, #d0814c)" />
+      <stop offset="100%" stop-color="var(--rock-shadow, #8f4a2d)" />
+    </linearGradient>
+    <linearGradient id="canyon-rock-front" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="var(--rock-front, #e09456)" />
+      <stop offset="100%" stop-color="var(--rock-depth, #b15d34)" />
+    </linearGradient>
+    <linearGradient id="desert-sand" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="var(--sand-light, #f2d4a0)" />
+      <stop offset="100%" stop-color="var(--sand-shadow, #d6a164)" />
+    </linearGradient>
+  </defs>
+  <g id="desert_canyon/sky">
+    <rect width="320" height="200" fill="url(#canyon-sky)" />
+    <circle cx="240" cy="56" r="28" fill="var(--sun, #ffdca3)" opacity="0.8" />
+  </g>
+  <g id="desert_canyon/mesas-back">
+    <path d="M0 120 L48 100 L96 110 L140 84 L192 94 L232 82 L320 110 L320 200 L0 200 Z" fill="url(#canyon-rock)" />
+    <path d="M50 122 h28 v18 h-28z" fill="var(--rock-highlight, #f0a46b)" opacity="0.6" />
+    <path d="M210 98 h32 v26 h-32z" fill="var(--rock-highlight, #f0a46b)" opacity="0.5" />
+  </g>
+  <g id="desert_canyon/mesas-front">
+    <path d="M0 148 L40 132 L88 144 L140 128 L180 142 L220 126 L270 136 L320 120 L320 200 L0 200 Z" fill="url(#canyon-rock-front)" />
+    <path d="M140 132 h18 v22 h-18z" fill="var(--rock-ridge, #d7713b)" opacity="0.6" />
+    <path d="M248 132 h20 v18 h-20z" fill="var(--rock-ridge, #d7713b)" opacity="0.6" />
+  </g>
+  <g id="desert_canyon/sand">
+    <path d="M0 170 C60 160 110 176 160 168 C220 158 270 182 320 170 L320 200 L0 200 Z" fill="url(#desert-sand)" />
+    <path d="M60 178 q30 -8 60 0" fill="none" stroke="var(--sand-line, #c68f4d)" stroke-width="3" stroke-linecap="round" opacity="0.4" />
+    <path d="M200 172 q30 -6 52 4" fill="none" stroke="var(--sand-line, #c68f4d)" stroke-width="3" stroke-linecap="round" opacity="0.35" />
+  </g>
+</svg>

--- a/docs/examples/svg_library/backgrounds/forest_glade.meta.yaml
+++ b/docs/examples/svg_library/backgrounds/forest_glade.meta.yaml
@@ -1,0 +1,23 @@
+summary: Sunlit forest clearing with layered evergreen silhouettes.
+groups:
+  - id: forest_glade/sky
+    role: soft blue sky backdrop
+    bounding_box: { x: 0, y: 0, width: 320, height: 200 }
+  - id: forest_glade/tree-line-back
+    role: distant tree canopy
+    bounding_box: { x: 0, y: 120, width: 320, height: 80 }
+  - id: forest_glade/tree-line-front
+    role: foreground tree canopy
+    bounding_box: { x: 0, y: 130, width: 320, height: 70 }
+  - id: forest_glade/meadow
+    role: grassy foreground strip
+    bounding_box: { x: 0, y: 170, width: 320, height: 30 }
+palette_tokens:
+  - --tree-deep
+  - --tree-mid
+  - --tree-light
+  - --meadow
+  - glade-sky
+recommended_usage:
+  - Natural backdrop for adventure scenes
+  - Combine with character layers for outdoor compositions

--- a/docs/examples/svg_library/backgrounds/forest_glade.svg
+++ b/docs/examples/svg_library/backgrounds/forest_glade.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 200">
+  <defs>
+    <linearGradient id="glade-sky" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#87d4ff" />
+      <stop offset="100%" stop-color="#f3fff5" />
+    </linearGradient>
+    <style>
+      :root {
+        --tree-deep: #1f4b2c;
+        --tree-mid: #2f6b3a;
+        --tree-light: #4d8f55;
+        --meadow: #c9e6a0;
+      }
+    </style>
+  </defs>
+  <g id="forest_glade/sky">
+    <rect x="0" y="0" width="320" height="200" fill="url(#glade-sky)" />
+  </g>
+  <g id="forest_glade/tree-line-back" opacity="0.8">
+    <path d="M0 140c20-30 40-30 60 0s40 30 60 0 40-30 60 0 40 30 60 0 40-30 80 0v60H0z" fill="var(--tree-mid)" />
+  </g>
+  <g id="forest_glade/tree-line-front">
+    <path d="M0 150c25-35 45-35 70 0s45 35 70 0 45-35 70 0 45 35 70 0 45-35 70 0v50H0z" fill="var(--tree-deep)" />
+  </g>
+  <g id="forest_glade/meadow">
+    <rect x="0" y="170" width="320" height="30" fill="var(--meadow)" />
+    <circle cx="40" cy="185" r="8" fill="var(--tree-light)" />
+    <circle cx="110" cy="180" r="6" fill="var(--tree-light)" />
+    <circle cx="200" cy="186" r="7" fill="var(--tree-light)" />
+  </g>
+</svg>

--- a/docs/examples/svg_library/characters/drone.meta.json
+++ b/docs/examples/svg_library/characters/drone.meta.json
@@ -1,0 +1,30 @@
+{
+  "summary": "Compact scout drone with expressive lenses and energy emitter.",
+  "groups": [
+    {
+      "id": "scout_drone/body",
+      "role": "primary chassis",
+      "bounding_box": { "x": 52, "y": 62, "width": 96, "height": 76 }
+    },
+    {
+      "id": "scout_drone/eyes",
+      "role": "dual optical sensors",
+      "bounding_box": { "x": 70, "y": 90, "width": 60, "height": 20 }
+    },
+    {
+      "id": "scout_drone/emitter",
+      "role": "downward light emitter",
+      "bounding_box": { "x": 82, "y": 122, "width": 36, "height": 16 }
+    },
+    {
+      "id": "scout_drone/wings",
+      "role": "hovering fins",
+      "bounding_box": { "x": 20, "y": 80, "width": 160, "height": 50 }
+    }
+  ],
+  "palette_tokens": ["--shell", "--shell-light", "--energy", "--accent"],
+  "recommended_usage": [
+    "Secondary character companion",
+    "Foreground hover element for tech scenes"
+  ]
+}

--- a/docs/examples/svg_library/characters/drone.svg
+++ b/docs/examples/svg_library/characters/drone.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <defs>
+    <style>
+      :root {
+        --shell: #4f5d75;
+        --shell-light: #7b88a8;
+        --energy: #4be1ff;
+        --accent: #ffb347;
+      }
+    </style>
+  </defs>
+  <g id="scout_drone/body">
+    <ellipse cx="100" cy="100" rx="48" ry="38" fill="var(--shell)" />
+    <ellipse cx="100" cy="100" rx="40" ry="30" fill="var(--shell-light)" />
+  </g>
+  <g id="scout_drone/eyes">
+    <circle cx="80" cy="100" r="10" fill="#0c1b2a" />
+    <circle cx="120" cy="100" r="10" fill="#0c1b2a" />
+    <circle cx="80" cy="100" r="6" fill="var(--energy)" />
+    <circle cx="120" cy="100" r="6" fill="var(--energy)" />
+  </g>
+  <g id="scout_drone/emitter" opacity="0.85">
+    <ellipse cx="100" cy="130" rx="18" ry="8" fill="var(--energy)" />
+  </g>
+  <g id="scout_drone/wings" opacity="0.6">
+    <path d="M52 96c-18-10-28-6-28-6 0 0 18 30 46 30l-18-24z" fill="var(--accent)" />
+    <path d="M148 96c18-10 28-6 28-6 0 0-18 30-46 30l18-24z" fill="var(--accent)" />
+  </g>
+</svg>

--- a/docs/examples/svg_library/characters/field_medic.meta.json
+++ b/docs/examples/svg_library/characters/field_medic.meta.json
@@ -1,0 +1,36 @@
+{
+  "summary": "Support android medic with reflective visor and dual supply packs.",
+  "groups": [
+    {
+      "id": "field_medic/body",
+      "role": "primary torso frame",
+      "bounding_box": { "x": 42, "y": 28, "width": 76, "height": 120 }
+    },
+    {
+      "id": "field_medic/visor",
+      "role": "translucent scanning visor",
+      "bounding_box": { "x": 54, "y": 38, "width": 52, "height": 28 }
+    },
+    {
+      "id": "field_medic/pack",
+      "role": "medic supply packs",
+      "bounding_box": { "x": 38, "y": 48, "width": 88, "height": 64 }
+    },
+    {
+      "id": "field_medic/accents",
+      "role": "status indicators and insignia",
+      "bounding_box": { "x": 56, "y": 96, "width": 48, "height": 44 }
+    }
+  ],
+  "palette_tokens": [
+    "--suit-top",
+    "--suit-base",
+    "--pack-light",
+    "--pack-dark",
+    "--visor-glow"
+  ],
+  "recommended_usage": [
+    "Foreground healer unit to pair with scouting drones",
+    "Contextual reference for medical support roles in prompts"
+  ]
+}

--- a/docs/examples/svg_library/characters/field_medic.svg
+++ b/docs/examples/svg_library/characters/field_medic.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+  <defs>
+    <linearGradient id="medic-suit" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="var(--suit-top, #e8f4ff)" />
+      <stop offset="100%" stop-color="var(--suit-base, #a9c8dd)" />
+    </linearGradient>
+    <linearGradient id="medic-pack" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="var(--pack-light, #74b5d6)" />
+      <stop offset="100%" stop-color="var(--pack-dark, #346b8a)" />
+    </linearGradient>
+  </defs>
+  <g id="field_medic/body">
+    <path d="M60 32 q20 -18 40 0 l8 18 v44 q0 18 -12 32 l-16 18 h-12 l-16 -18 q-12 -14 -12 -32 V50z" fill="url(#medic-suit)" stroke="var(--suit-outline, #5c7c92)" stroke-width="2" stroke-linejoin="round" />
+    <rect x="66" y="96" width="28" height="32" rx="12" fill="var(--suit-core, #7ea2b8)" opacity="0.6" />
+  </g>
+  <g id="field_medic/visor">
+    <path d="M58 48 q22 -20 44 0 q-6 16 -22 16 q-16 0 -22 -16z" fill="var(--visor-glow, #3ed0ff)" opacity="0.85" />
+    <path d="M62 48 q16 -12 32 0" fill="none" stroke="var(--visor-highlight, #b7f3ff)" stroke-width="3" stroke-linecap="round" />
+  </g>
+  <g id="field_medic/pack">
+    <rect x="42" y="58" width="18" height="44" rx="8" fill="url(#medic-pack)" />
+    <rect x="100" y="58" width="18" height="44" rx="8" fill="url(#medic-pack)" />
+    <rect x="54" y="44" width="52" height="16" rx="8" fill="var(--pack-link, #4f88a7)" />
+    <path d="M58 66 h12 v12 h-12z" fill="var(--pack-badge, #ff6f6f)" />
+    <path d="M94 66 h12 v12 h-12z" fill="var(--pack-badge, #ff6f6f)" />
+  </g>
+  <g id="field_medic/accents">
+    <path d="M74 120 l6 12 l6 -12" fill="none" stroke="var(--accent-line, #ff9f6f)" stroke-width="3" stroke-linecap="round" />
+    <circle cx="60" cy="104" r="4" fill="var(--indicator, #ffe7a0)" />
+    <circle cx="100" cy="104" r="4" fill="var(--indicator, #ffe7a0)" />
+  </g>
+</svg>

--- a/docs/examples/svg_library/effects/energy_ring.meta.json
+++ b/docs/examples/svg_library/effects/energy_ring.meta.json
@@ -1,0 +1,33 @@
+{
+  "summary": "Cyan energy ring with layered glow and sparks for motion accents.",
+  "groups": [
+    {
+      "id": "energy_ring/base-glow",
+      "role": "diffuse energy field",
+      "bounding_box": { "x": 18, "y": 18, "width": 164, "height": 164 }
+    },
+    {
+      "id": "energy_ring/inner-ring",
+      "role": "intense focal ring",
+      "bounding_box": { "x": 42, "y": 42, "width": 116, "height": 116 }
+    },
+    {
+      "id": "energy_ring/outer-ring",
+      "role": "soft highlight rim",
+      "bounding_box": { "x": 12, "y": 12, "width": 176, "height": 176 }
+    },
+    {
+      "id": "energy_ring/sparks",
+      "role": "floating energy sparks",
+      "bounding_box": { "x": 40, "y": 40, "width": 140, "height": 120 }
+    }
+  ],
+  "palette_tokens": ["--ring-highlight", "--ring-accent", "ring-core"],
+  "blend_modes": {
+    "default": "screen"
+  },
+  "recommended_usage": [
+    "Add motion to tech interfaces",
+    "Overlay around characters or artifacts"
+  ]
+}

--- a/docs/examples/svg_library/effects/energy_ring.svg
+++ b/docs/examples/svg_library/effects/energy_ring.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <defs>
+    <radialGradient id="ring-core" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="rgba(75, 225, 255, 0.9)" />
+      <stop offset="60%" stop-color="rgba(75, 225, 255, 0.2)" />
+      <stop offset="100%" stop-color="rgba(75, 225, 255, 0)" />
+    </radialGradient>
+    <style>
+      :root {
+        --ring-highlight: rgba(255, 255, 255, 0.8);
+        --ring-accent: rgba(0, 198, 255, 0.9);
+      }
+    </style>
+  </defs>
+  <g id="energy_ring/base-glow" opacity="0.75">
+    <circle cx="100" cy="100" r="82" fill="url(#ring-core)" />
+  </g>
+  <g id="energy_ring/inner-ring">
+    <circle cx="100" cy="100" r="58" fill="none" stroke="var(--ring-accent)" stroke-width="6" stroke-dasharray="18 12" />
+  </g>
+  <g id="energy_ring/outer-ring" opacity="0.6">
+    <circle cx="100" cy="100" r="92" fill="none" stroke="var(--ring-highlight)" stroke-width="4" stroke-dasharray="8 10" />
+  </g>
+  <g id="energy_ring/sparks">
+    <circle cx="60" cy="60" r="4" fill="var(--ring-highlight)" />
+    <circle cx="142" cy="46" r="3" fill="var(--ring-highlight)" />
+    <circle cx="158" cy="132" r="4" fill="var(--ring-highlight)" />
+    <circle cx="44" cy="128" r="3" fill="var(--ring-highlight)" />
+  </g>
+</svg>

--- a/docs/examples/svg_library/effects/signal_wave.meta.json
+++ b/docs/examples/svg_library/effects/signal_wave.meta.json
@@ -1,0 +1,31 @@
+{
+  "summary": "Radiating signal wave effect with concentric rings and flares.",
+  "groups": [
+    {
+      "id": "signal_wave/core",
+      "role": "central emission source",
+      "bounding_box": { "x": 84, "y": 84, "width": 72, "height": 72 }
+    },
+    {
+      "id": "signal_wave/rings",
+      "role": "expanding energy rings",
+      "bounding_box": { "x": 24, "y": 24, "width": 192, "height": 192 }
+    },
+    {
+      "id": "signal_wave/flares",
+      "role": "directional burst accents",
+      "bounding_box": { "x": 24, "y": 24, "width": 192, "height": 192 }
+    }
+  ],
+  "palette_tokens": [
+    "--core-bright",
+    "--ring-primary",
+    "--ring-secondary",
+    "--ring-tertiary",
+    "--flare"
+  ],
+  "recommended_usage": [
+    "Layer behind characters to suggest communications or sonar",
+    "Blend with sci-fi interfaces as a looping signal motif"
+  ]
+}

--- a/docs/examples/svg_library/effects/signal_wave.svg
+++ b/docs/examples/svg_library/effects/signal_wave.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">
+  <defs>
+    <radialGradient id="signal-core" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="var(--core-bright, #7af6ff)" />
+      <stop offset="70%" stop-color="var(--core-mid, #2fb7d6)" stop-opacity="0.8" />
+      <stop offset="100%" stop-color="var(--core-dark, #0c3f5a)" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <g id="signal_wave/core">
+    <circle cx="120" cy="120" r="36" fill="url(#signal-core)" />
+    <circle cx="120" cy="120" r="18" fill="var(--core-highlight, #caffff)" opacity="0.4" />
+  </g>
+  <g id="signal_wave/rings">
+    <circle cx="120" cy="120" r="58" fill="none" stroke="var(--ring-primary, #4fe3ff)" stroke-width="6" opacity="0.7" />
+    <circle cx="120" cy="120" r="86" fill="none" stroke="var(--ring-secondary, #36b6e2)" stroke-width="5" opacity="0.45" stroke-dasharray="12 10" />
+    <circle cx="120" cy="120" r="112" fill="none" stroke="var(--ring-tertiary, #1c7aa0)" stroke-width="4" opacity="0.3" stroke-dasharray="6 16" />
+  </g>
+  <g id="signal_wave/flares">
+    <path d="M120 34 l8 24 h-16z" fill="var(--flare, #b8f4ff)" opacity="0.5" />
+    <path d="M206 120 l-24 8 v-16z" fill="var(--flare, #b8f4ff)" opacity="0.5" />
+    <path d="M120 206 l-8 -24 h16z" fill="var(--flare, #b8f4ff)" opacity="0.45" />
+    <path d="M34 120 l24 -8 v16z" fill="var(--flare, #b8f4ff)" opacity="0.45" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add a desert canyon background SVG with layered mesa groups and metadata guidance
- introduce a field medic support character asset plus JSON metadata for groups and palettes
- supply a signal wave effect SVG with companion metadata and document the expanded library layout

## Testing
- not run (asset and documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68dec3aa17f0832a8148ec20bf43d7b3