### PR TITLE
Allow CAIBridge to accept custom session store

### DIFF
--- a/src/caiengine/cai_bridge.py
+++ b/src/caiengine/cai_bridge.py
@@ -45,9 +45,10 @@ class CAIBridge:
         one_direction_layers: Optional[List[str]] | None = None,
         workflow: str | None = None,
         marketing_config: Optional[Dict[str, Any]] = None,
+        session_store: Optional[Any] = None,
     ) -> None:
         self.goal_state = goal_state or {}
-        self._session_store = _SessionContextStore()
+        self._session_store = session_store or _SessionContextStore()
         self._connector_registry: Any | None = None
         self._persona_loader: Optional[Callable[[str], Dict[str, Any]]] = None
         self._active_persona: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
## Summary
- allow `CAIBridge` to accept an injected session store so session data can be persisted across runs
- add test coverage ensuring custom session stores are used for metadata and attempt tracking

## Testing
- pytest tests/test_cai_bridge.py

------
https://chatgpt.com/codex/tasks/task_e_68ded0b0737c832abcc098f16712a771