### PR TITLE
Fix FileContextProvider.publish_context return value

### DIFF
--- a/src/caiengine/providers/file_context_provider.py
+++ b/src/caiengine/providers/file_context_provider.py
@@ -103,7 +103,7 @@ class FileContextProvider:
         source_id: str = "file",
         confidence: float = 1.0,
     ):
-        self.ingest_context(payload, timestamp, metadata, source_id, confidence)
+        return self.ingest_context(payload, timestamp, metadata, source_id, confidence)
 
     def _to_dict(self, cd: ContextData) -> dict:
         return {


### PR DESCRIPTION
## Summary
- ensure `FileContextProvider.publish_context` returns the generated context identifier instead of discarding it

## Testing
- pytest tests/test_file_context_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68e22053d594832aa9a407b50679f1e3