### PR TITLE
PoC: Layered context names + GoalGraph JSON round-trip for orchestration PoC

### DIFF
--- a/docs/getting_started/multi_expert_orchestration_poc.md
+++ b/docs/getting_started/multi_expert_orchestration_poc.md
@@ -13,6 +13,8 @@ Success criteria covered by the PoC script:
    layers are included.
 3. With a simple reward signal, adaptive routing (`EpsilonGreedyRoutingPolicy`)
    improves expert selection over time.
+4. Workflow graphs can be stored as portable JSON payloads via
+   `GoalGraph.to_dict()` / `GoalGraph.from_dict()`.
 
 Non-goals:
 
@@ -50,5 +52,14 @@ The script prints three sections, one for each criterion.
   metadata.
 - Criterion 2 should show fewer layers with the tight budget than with the
   roomy budget.
+- In Criterion 2, layer naming communicates abstraction depth, for example:
+  - `goal.meal` (general),
+  - `goal.meal.constraints` (more specific),
+  - `retrieved.items` (observations),
+  - `retrieved.items.pantry` and `retrieved.items.calendar` (deeper sources).
+  Changing `budget.max_layers` / `budget.max_chars` should determine whether
+  only broad layers or deeper layers are passed onward.
 - Criterion 3 should select a baseline expert before rewards and prefer the
   higher-reward expert after repeated outcomes are recorded.
+- Criterion 4 should print serialized graph JSON and confirm round-trip
+  stability (`True`).

--- a/docs/multi-expert-orchestration-poc.md
+++ b/docs/multi-expert-orchestration-poc.md
@@ -14,7 +14,40 @@ The script prints:
 - selected and omitted context layers,
 - chosen experts,
 - confidence scores,
-- final output payload.
+- final output payload,
+- workflow graph JSON round-trip output.
+
+## Layer naming tip (abstraction depth)
+
+The PoC now uses layer names that encode specificity:
+
+- `goal.meal` (general intent),
+- `goal.meal.constraints` (deeper constraints),
+- `retrieved.items` (broad observations),
+- `retrieved.items.pantry` / `retrieved.items.calendar` (deeper observations).
+
+This makes it easy to tune how much detail reaches experts by only changing
+budget fields.
+
+## Budget tuning behavior
+
+Criterion 2 compares:
+
+- a tight budget (small `max_layers` / `max_chars`) that tends to pass mostly
+  higher-level layers, and
+- a roomy budget that can include deeper constraint and observation layers.
+
+Use this as a proxy for "reasoning depth" in prompt assembly before introducing
+a full GoalGraph executor.
+
+## Portable workflow graph payloads
+
+Criterion 4 demonstrates storing a workflow graph as JSON using
+`GoalGraph.to_dict()` / `GoalGraph.from_dict()`.
+
+That keeps graphs layered and portable in the same spirit as the event context
+standard, and prepares artifacts for later execution when a graph executor is
+added.
 
 ## What this demonstrates
 

--- a/simulation/multi_expert_orchestration_poc.py
+++ b/simulation/multi_expert_orchestration_poc.py
@@ -123,27 +123,35 @@ def criterion_1_metadata_changes_expert_selection() -> None:
 def criterion_2_budget_changes_context_packet_layers() -> None:
     print("\n=== Criterion 2: budget changes selected context layers ===")
 
-    pipeline = OrchestratedPipeline(context_provider=_build_provider(), registry=_build_registry())
+    class Criterion2Provider:
+        def get_context(self, _query: Any | None = None) -> dict[str, Any]:
+            return {
+                "pantry": ["rice", "eggs", "spinach"],
+                "calendar": {"weekday": "Wednesday", "available_minutes": 35},
+            }
+
+    pipeline = OrchestratedPipeline(context_provider=Criterion2Provider(), registry=_build_registry())
     request = {
         "category": "support",
         "scope": "customer",
         "tags": ["text", "urgent"],
         "required_layers": ["retrieved.items"],
-        "optional_layers": [
-            "goal.meal",
-            "goal.meal.constraints",
-            "retrieved.items.pantry",
-            "retrieved.items.calendar",
-            "request",
-        ],
     }
 
     tight_budget = {
+        "meal": {
+            "name": "quick_spinach_eggs",
+            "constraints": {"max_budget_pln": 40, "diet": "vegetarian"},
+        },
         "required_layers": ["retrieved.items"],
         "optional_layers": ["goal.meal"],
         "budget": {"max_layers": 2, "max_chars": 220},
     }
     roomy_budget = {
+        "meal": {
+            "name": "quick_spinach_eggs",
+            "constraints": {"max_budget_pln": 40, "diet": "vegetarian"},
+        },
         "required_layers": ["retrieved.items"],
         "optional_layers": [
             "goal.meal",


### PR DESCRIPTION
### Motivation
- Make the multi-expert orchestration PoC closer to a layered/graph-based workflow by encoding abstraction depth in layer names and demonstrating how budget settings affect which layers are passed.
- Prepare for a future GoalGraph executor by showing how workflow graphs can be serialized and restored as portable JSON using the existing `GoalGraph.to_dict()` / `GoalGraph.from_dict()` API.

### Description
- Updated `simulation/multi_expert_orchestration_poc.py` to introduce depth-encoded layer names such as `goal.meal`, `goal.meal.constraints`, `retrieved.items.pantry`, and `retrieved.items.calendar`, and to show tight vs roomy `budget.max_layers` / `budget.max_chars` effects on selected layers.
- Added a new criterion that builds a `GoalGraph`, serializes it with `GoalGraph.to_dict()`, rehydrates it with `GoalGraph.from_dict()`, and prints the serialized JSON and round-trip stability check.
- Added pantry/calendar example fields to the in-memory context provider payloads used by the PoC to illustrate deeper observation layers.
- Extended documentation in `docs/multi-expert-orchestration-poc.md` and `docs/getting_started/multi_expert_orchestration_poc.md` to describe the layer-naming tip, budget tuning behavior, and the graph JSON round-trip portability.

### Testing
- Ran `python -m compileall simulation/multi_expert_orchestration_poc.py docs/multi-expert-orchestration-poc.md docs/getting_started/multi_expert_orchestration_poc.md`, which succeeded and confirmed the modified Python file compiles.
- Attempted to execute the PoC script directly (`python simulation/multi_expert_orchestration_poc.py`), which failed in this environment due to missing project/dependency imports (`caiengine` / `pydantic`).
- Attempted to run via `PYTHONPATH=src python simulation/multi_expert_orchestration_poc.py`, which also failed due to missing `pydantic` in the container; therefore runtime output (including the serialized graph print) could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b33d732ac832ab3134e41b39b1ede)